### PR TITLE
relocate tentative score

### DIFF
--- a/liwords-ui/src/gameroom/board.tsx
+++ b/liwords-ui/src/gameroom/board.tsx
@@ -45,6 +45,7 @@ const Board = React.memo((props: Props) => {
           lastPlayedTiles={props.lastPlayedTiles}
           tentativeTiles={props.tentativeTiles}
           scaleTiles={true}
+          placementArrow={props.placementArrowProperties}
           tentativeTileScore={props.tentativeTileScore}
         />
       </div>

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -429,12 +429,20 @@
   border-radius: 10%;
   font-size: 12px;
   font-weight: bold;
-  margin: 1px;
-  left: -100%;
+  opacity: 0.8;
   border: 1px solid $color-timer-dark;
   background: $color-timer-light;
   color: $color-timer-dark;
 }
+
+.tile .tentative-score.tentative-score-horizontal {
+  right: 100%;
+}
+
+.tile .tentative-score.tentative-score-vertical {
+  bottom: 100%;
+}
+
 .tile:hover {
   .tentative-score {
   }

--- a/liwords-ui/src/gameroom/tentative_score.tsx
+++ b/liwords-ui/src/gameroom/tentative_score.tsx
@@ -1,13 +1,20 @@
 import React from 'react';
 
 type Props = {
-  score?: number;
+  score: number | undefined;
+  horizontal: boolean | undefined;
 };
 
 const TentativeScore = (props: Props) => {
-  if (props.score) {
+  if (props.score != null) {
     return (
-      <p className="tentative-score">
+      <p
+        className={`tentative-score ${
+          props.horizontal
+            ? 'tentative-score-horizontal'
+            : 'tentative-score-vertical'
+        }`}
+      >
           {props.score}
       </p>
     );

--- a/liwords-ui/src/gameroom/tile.tsx
+++ b/liwords-ui/src/gameroom/tile.tsx
@@ -76,6 +76,7 @@ type TileProps = {
   scale?: boolean;
   tentative?: boolean;
   tentativeScore?: number;
+  tentativeScoreIsHorizontal?: boolean | undefined;
   grabbable: boolean;
   rackIndex?: number | undefined;
   selected?: boolean;
@@ -163,7 +164,10 @@ const Tile = React.memo((props: TileProps) => {
     >
       <TileLetter rune={props.rune} />
       <PointValue value={props.value} />
-      <TentativeScore score={props.tentativeScore} />
+      <TentativeScore
+        score={props.tentativeScore}
+        horizontal={props.tentativeScoreIsHorizontal}
+      />
     </div>
   );
 });

--- a/liwords-ui/src/gameroom/tiles.tsx
+++ b/liwords-ui/src/gameroom/tiles.tsx
@@ -5,12 +5,14 @@ import {
   runeToValues,
 } from '../constants/tile_values';
 import Tile from './tile';
-import { EphemeralTile, PlayedTiles } from '../utils/cwgame/common';
+import { EmptySpace, EphemeralTile, PlayedTiles } from '../utils/cwgame/common';
+import { PlacementArrow } from '../utils/cwgame/tile_placement';
 
 type Props = {
   gridDim: number;
   tilesLayout: string;
   lastPlayedTiles: PlayedTiles;
+  placementArrow: PlacementArrow;
   scaleTiles: boolean;
   tentativeTiles: Set<EphemeralTile>;
   tentativeTileScore: number | undefined;
@@ -34,11 +36,74 @@ const Tiles = React.memo((props: Props) => {
     return a.col - b.col;
   });
 
-  let tentativeTilesRemaining = tentativeTiles.length;
+  let tentativeScoreStyle;
+  let isHorizontal;
+  if (tentativeTiles.length > 0) {
+    let minRow = tentativeTiles[0].row;
+    let maxRow = minRow;
+    let minCol = tentativeTiles[0].col;
+    let maxCol = minCol;
+    for (let i = 1; i < tentativeTiles.length; ++i) {
+      const { row, col } = tentativeTiles[i];
+      minRow = Math.min(minRow, row);
+      maxRow = Math.max(maxRow, row);
+      minCol = Math.min(minCol, col);
+      maxCol = Math.max(maxCol, col);
+    }
+    if (minRow === maxRow) {
+      isHorizontal = true;
+      // TODO: put Board in useContext and use letterAt instead of indexing directly into tilesLayout?
+      if (
+        minCol === maxCol &&
+        props.placementArrow?.show &&
+        !props.placementArrow.horizontal &&
+        props.placementArrow.col === minCol
+      ) {
+        // only one tile was placed, use vertical iff placementArrow says so
+        let y = maxRow;
+        do ++y;
+        while (
+          y < props.gridDim &&
+          props.tilesLayout[y * props.gridDim + minCol] !== EmptySpace
+        );
+        if (y === props.placementArrow.row) isHorizontal = false;
+      }
+    } else if (minCol === maxCol) {
+      isHorizontal = false;
+    }
+
+    if (isHorizontal === true) {
+      let x = minCol;
+      do --x;
+      while (
+        x > 0 &&
+        props.tilesLayout[minRow * props.gridDim + x] !== EmptySpace
+      );
+      tentativeScoreStyle = { row: minRow, col: x + 1 };
+    } else if (isHorizontal === false) {
+      let y = minRow;
+      do --y;
+      while (
+        y > 0 &&
+        props.tilesLayout[y * props.gridDim + minCol] !== EmptySpace
+      );
+      tentativeScoreStyle = { row: y + 1, col: minCol };
+    }
+  }
 
   for (let y = 0; y < props.gridDim; y += 1) {
     for (let x = 0; x < props.gridDim; x += 1) {
       const rune = props.tilesLayout[y * 15 + x];
+      const tentativeScoreIsHere =
+        tentativeScoreStyle &&
+        tentativeScoreStyle.row === y &&
+        tentativeScoreStyle.col === x;
+      const tentativeScoreHere = tentativeScoreIsHere
+        ? props.tentativeTileScore
+        : undefined;
+      const tentativeScoreHereIsHorizontal = tentativeScoreIsHere
+        ? isHorizontal
+        : undefined;
       if (rune !== ' ') {
         const lastPlayed = props.lastPlayedTiles[`R${y}C${x}`] === true;
         tiles.push(
@@ -48,6 +113,8 @@ const Tiles = React.memo((props: Props) => {
             lastPlayed={lastPlayed}
             key={`tile_${x}_${y}`}
             scale={props.scaleTiles}
+            tentativeScore={tentativeScoreHere}
+            tentativeScoreIsHorizontal={tentativeScoreHereIsHorizontal}
             grabbable={false}
           />
         );
@@ -69,15 +136,11 @@ const Tiles = React.memo((props: Props) => {
               tentative={true}
               x={x}
               y={y}
-              tentativeScore={
-                tentativeTilesRemaining === tentativeTiles.length
-                  ? props.tentativeTileScore
-                  : undefined
-              }
+              tentativeScore={tentativeScoreHere}
+              tentativeScoreIsHorizontal={tentativeScoreHereIsHorizontal}
               grabbable={true}
             />
           );
-          tentativeTilesRemaining -= 1;
         } else {
           tiles.push(
             <div

--- a/liwords-ui/src/gameroom/tiles.tsx
+++ b/liwords-ui/src/gameroom/tiles.tsx
@@ -76,7 +76,7 @@ const Tiles = React.memo((props: Props) => {
       let x = minCol;
       do --x;
       while (
-        x > 0 &&
+        x >= 0 &&
         props.tilesLayout[minRow * props.gridDim + x] !== EmptySpace
       );
       tentativeScoreStyle = { row: minRow, col: x + 1 };
@@ -84,7 +84,7 @@ const Tiles = React.memo((props: Props) => {
       let y = minRow;
       do --y;
       while (
-        y > 0 &&
+        y >= 0 &&
         props.tilesLayout[y * props.gridDim + minCol] !== EmptySpace
       );
       tentativeScoreStyle = { row: y + 1, col: minCol };


### PR DESCRIPTION
This pull request moves the tentative score, currently always to the left of the first tentative tile, to just before the first tile of the main word, which can either be an empty square or just outside the board, but never a non-empty square.

For horizontal plays, this resolves the issue when extending an existing word.

For vertical plays, this resolves the issue when hooking to the right of an existing word. (For vertical plays, the tentative score is placed above and not to the left of the first tile.)

When only a single tile is placed, the tentative score is placed according to the placement arrow. Unfortunately if the placement arrow is no longer there, it is ambiguous, and this pull request defaults to horizontal.

Additionally, this pull request makes it so that the tentative score will display even if it is zero (as is the case when placing a blank tile next to another).