### PR TITLE
remove stray comma after exchange button

### DIFF
--- a/liwords-ui/src/gameroom/exchange_tiles.tsx
+++ b/liwords-ui/src/gameroom/exchange_tiles.tsx
@@ -115,7 +115,6 @@ export const ExchangeTiles = (props: Props) => {
           >
             Exchange
           </Button>
-          ,
         </>,
       ]}
     >


### PR DESCRIPTION
just turning

<img width="377" alt="Screenshot 2020-10-06 at 14 27 15" src="https://user-images.githubusercontent.com/4179698/95166247-1b7a4a00-07e0-11eb-87fe-321179a584ec.png">

into

<img width="370" alt="Screenshot 2020-10-06 at 14 27 32" src="https://user-images.githubusercontent.com/4179698/95166251-1d440d80-07e0-11eb-8241-37cb854427f2.png">
