### PR TITLE
fix timeout penalty

### DIFF
--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -374,6 +374,8 @@ func HandleEvent(ctx context.Context, gameStore GameStore, userStore user.Store,
 	// Turn the event into a macondo GameEvent.
 	if cge.Type == pb.ClientGameplayEvent_RESIGN {
 		entGame.SetGameEndReason(pb.GameEndReason_RESIGNED)
+		// Player may have accrued overtime penalties before resigning.
+		entGame.RecordTimeOfMove(onTurn)
 		winner := 1 - onTurn
 		entGame.History().Winner = int32(winner)
 		entGame.SetWinnerIdx(winner)

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -260,6 +260,9 @@ func handleChallenge(ctx context.Context, entGame *entity.Game,
 	if entGame.Game.Playing() == macondopb.PlayState_GAME_OVER {
 		if entGame.ChallengeRule() == macondopb.ChallengeRule_TRIPLE {
 			entGame.SetGameEndReason(pb.GameEndReason_TRIPLE_CHALLENGE)
+			// Player may have accrued overtime penalties before challenging.
+			onTurn := entGame.PlayerOnTurn()
+			entGame.RecordTimeOfMove(onTurn)
 			winner := int(entGame.History().Winner)
 			entGame.SetWinnerIdx(winner)
 			entGame.SetLoserIdx(1 - winner)


### PR DESCRIPTION
It seems that, whenever a game ends in timeout:

The losing player always overtimes by the maximum amount.
Not less, even if no moves in the final minute.
Not more, even if game is abandoned and resumed/adjudicated much later.

And the player on turn is always the losing player.

Additionally, for games allowing less than 5 minutes max overtime (including increment games, which currently have zero max overtime) the penalty should follow the max overtime instead of a hardcoded -50.

This pull request aims to fix cases identified so far relating to the wrong overtime penalty being assessed for games ending in timeout.

~~This pull request does not fix the wrong overtime penalty issue for games ending in other reasons like resigning or losing a triple-challenge.~~

(Update: It fixes the wrong overtime penalty issue for games ending in resigning and triple-challenge, too.)

This pull request does not fix the wrong overtime penalty issue for games ending in any other reasons.