### PR TITLE
let observers report timeout

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -129,8 +129,7 @@ export const Table = React.memo((props: Props) => {
   useEffect(() => {
     if (pTimedOut === undefined) return;
     // Otherwise, player timed out. This will only send once.
-    // Send the time out if we're either of both players that are in the game.
-    if (isObserver) return;
+    // Observers also send the time out, to clean up noticed abandoned games.
 
     let timedout = '';
 


### PR DESCRIPTION
When games are abandoned by both players, they weren't adjudicated until either player returns.

This patch allows observers to report the timeout they noticed.

So when an observer, who may not even be logged in, observes the game, it would trigger the timeout and adjudicate the game accordingly, cleaning up the list of watchable games.

This (-1)-line patch seems to achieve most of the intended benefits of auto-adjudication?

I have no idea why this seems to work 😄