### PR TITLE
do not wrap game controls

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -633,11 +633,19 @@
 }
 .game-controls {
   margin: 0 auto;
+  white-space: nowrap;
   button {
     margin: 0 6px;
     padding: 0;
   }
+  & > :first-child {
+    margin-left: 0;
+  }
+  & > :last-child {
+    margin-right: 0;
+  }
 }
+
 .end-message {
   background-color: $color-primary-middle;
   .ant-card-body {


### PR DESCRIPTION
After adding the best button ever

<img width="436" alt="Screenshot 2020-10-07 at 14 48 42" src="https://user-images.githubusercontent.com/4179698/95298541-cce7b100-08ae-11eb-9c9e-558503af0ba8.png">

we need to disable wrapping

<img width="509" alt="Screenshot 2020-10-07 at 14 48 51" src="https://user-images.githubusercontent.com/4179698/95298556-d3762880-08ae-11eb-8345-41b5326aa2f2.png">
