### PR TITLE
Issue 84 - Disable double click of rematch button.

### DIFF
--- a/liwords-ui/src/gameroom/game_controls.test.tsx
+++ b/liwords-ui/src/gameroom/game_controls.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import GameControls, { Props } from './game_controls';
+
+function renderGameControls(props: Partial<Props> = {}) {
+  const dummyFunction = () => {
+    return;
+  };
+  const defaultProps: Props = {
+    exchangeAllowed: false,
+    finalPassOrChallenge: false,
+    myTurn: false,
+    observer: false,
+    showExchangeModal: dummyFunction,
+    onPass: dummyFunction,
+    onResign: dummyFunction,
+    onRecall: dummyFunction,
+    onChallenge: dummyFunction,
+    onCommit: dummyFunction,
+    onExamine: dummyFunction,
+    onRematch: dummyFunction,
+    gameEndControls: false,
+    showRematch: false,
+    currentRack: '',
+  };
+  return render(<GameControls {...defaultProps} {...props} />);
+}
+
+afterEach(cleanup);
+
+it('fires clicks on rematch only once', async () => {
+  const onRematch = jest.fn();
+  const { findByTestId } = renderGameControls({
+    gameEndControls: true,
+    onRematch: onRematch,
+    showRematch: true,
+  });
+  const rematchButton = await findByTestId('rematch-button');
+  expect(rematchButton).toBeVisible();
+  fireEvent.click(rematchButton);
+  fireEvent.click(rematchButton);
+  expect(onRematch).toHaveBeenCalledTimes(1);
+});

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Button, Popconfirm } from 'antd';
 
-type Props = {
+export type Props = {
   exchangeAllowed?: boolean;
   finalPassOrChallenge?: boolean;
   myTurn?: boolean;
@@ -97,6 +97,7 @@ const EndGameControls = (props: EGCProps) => {
       {props.showRematch && !rematchDisabled && (
         <Button
           type="primary"
+          data-testid="rematch-button"
           onClick={() => {
             setRematchDisabled(true);
             if (!rematchDisabled) {

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Button, Popconfirm } from 'antd';
 
 type Props = {
@@ -87,17 +87,28 @@ type EGCProps = {
   onExamine: () => void;
 };
 
-const EndGameControls = (props: EGCProps) => (
-  <div className="game-controls">
-    <Button>Options</Button>
-    <Button onClick={props.onExamine}>Export GCG</Button>
-    <Button onClick={() => window.location.replace('/')}>Exit</Button>
-    {props.showRematch && (
-      <Button type="primary" onClick={props.onRematch}>
-        Rematch
-      </Button>
-    )}
-  </div>
-);
+const EndGameControls = (props: EGCProps) => {
+  const [rematchDisabled, setRematchDisabled] = useState(false);
+  return (
+    <div className="game-controls">
+      <Button>Options</Button>
+      <Button onClick={props.onExamine}>Export GCG</Button>
+      <Button onClick={() => window.location.replace('/')}>Exit</Button>
+      {props.showRematch && !rematchDisabled && (
+        <Button
+          type="primary"
+          onClick={() => {
+            setRematchDisabled(true);
+            if (!rematchDisabled) {
+              props.onRematch();
+            }
+          }}
+        >
+          Rematch
+        </Button>
+      )}
+    </div>
+  );
+};
 
 export default GameControls;


### PR DESCRIPTION
Prevents double clicking rematch but this is nearly impossible to replicate locally, so I kinda wonder if the bot (or different instances of it??) isn't picking up twice in a race condition.