### PR TITLE
fix backend logout endpoint

### DIFF
--- a/pkg/stores/session/db.go
+++ b/pkg/stores/session/db.go
@@ -98,5 +98,6 @@ func (s *DBStore) Delete(ctx context.Context, sess *entity.Session) error {
 	if sess.ID == "" {
 		return errors.New("session has a blank ID, cannot be deleted")
 	}
-	return s.db.Delete(sess).Error
+	// We want to delete from db_sessions, not delete from sessions
+	return s.db.Delete(&dbSession{UUID: sess.ID}).Error
 }


### PR DESCRIPTION
the reason #91 failed with 500 is it was trying to `delete from sessions` when it should be `delete from db_sessions`.