### PR TITLE
fix enter key handling on exchange modal

### DIFF
--- a/liwords-ui/src/gameroom/exchange_tiles.tsx
+++ b/liwords-ui/src/gameroom/exchange_tiles.tsx
@@ -31,8 +31,16 @@ export const ExchangeTiles = (props: Props) => {
       if (delayInput || !props.modalVisible) {
         return;
       }
-      if (e.key === 'Enter' && exchangedRack.length) {
-        props.onOk(exchangedRack);
+      if (e.key === 'Enter') {
+        // Prevent also activating the focused button.
+        // Previously, if the Exchange button was clicked,
+        // pressing Enter would reactivate the exchange modal.
+        // This did not happen when using the shortcut.
+        e.preventDefault();
+        if (exchangedRack.length) {
+          props.onOk(exchangedRack);
+        }
+        return;
       }
       const key = e.key.toLocaleUpperCase();
       const tempToExchange = new Set<number>(exchangedRackIndices);


### PR DESCRIPTION
fixes #105 

Previously Enter key on the exchange modal not only performed the exchange, it also activated whatever button was focused.

- If the player clicked on Exchange button, the Exchange button was focused. This meant pressing Enter on the Exchange modal would reopen the Exchange modal.
- If the player pressed `4` to bring up the Exchange modal, this did not happen.
- Though unlikely, one of the other buttons may be focused instead. For example, by clicking Exchange, pressing Esc, and then pressing Shift+Tab three times, the Ragequit button is focused. Now, press `4`, and try to exchange; the Ragequit popup then activates. Similarly if the focus was on Pass, exchanging will also send Pass as the next move. Scary!