### PR TITLE
Fixes tiles vanishing after you type into the bottom right corner (so…

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -392,7 +392,11 @@ export const BoardPanel = React.memo((props: Props) => {
   };
 
   const clickToBoard = (rackIndex: number) => {
-    if (!arrowProperties.show) {
+    if (
+      !arrowProperties.show ||
+      arrowProperties.row >= props.board.dim ||
+      arrowProperties.col >= props.board.dim
+    ) {
       return null;
     }
     const handlerReturn = handleDroppedTile(


### PR DESCRIPTION
(so you lose your arrow), then click on one. It will stay invisible until you hit reset or shuffle.