### PR TITLE
improve timer rerender

### DIFF
--- a/liwords-ui/src/store/timer_controller.test.ts
+++ b/liwords-ui/src/store/timer_controller.test.ts
@@ -1,17 +1,35 @@
 import { millisToTimeStr } from './timer_controller';
 
 it('tests millis to time', () => {
+  expect(millisToTimeStr(3600000)).toEqual('60:00');
+  expect(millisToTimeStr(3599001)).toEqual('60:00');
+  expect(millisToTimeStr(3599000)).toEqual('59:59');
   expect(millisToTimeStr(479900)).toEqual('08:00');
   expect(millisToTimeStr(479000)).toEqual('07:59');
   expect(millisToTimeStr(60000)).toEqual('01:00');
   expect(millisToTimeStr(59580)).toEqual('01:00');
+  expect(millisToTimeStr(11000)).toEqual('00:11');
+  expect(millisToTimeStr(10001)).toEqual('00:11');
+  expect(millisToTimeStr(10000)).toEqual('00:10.0');
+  expect(millisToTimeStr(9901)).toEqual('00:10.0');
+  expect(millisToTimeStr(9900)).toEqual('00:09.9');
   expect(millisToTimeStr(8900)).toEqual('00:08.9');
   expect(millisToTimeStr(890)).toEqual('00:00.9');
+  expect(millisToTimeStr(101)).toEqual('00:00.2');
+  expect(millisToTimeStr(100)).toEqual('00:00.1');
+  expect(millisToTimeStr(1)).toEqual('00:00.1');
+  expect(millisToTimeStr(0)).toEqual('00:00.0');
   expect(millisToTimeStr(-1)).toEqual('-00:00.0');
   expect(millisToTimeStr(-40)).toEqual('-00:00.0');
-  expect(millisToTimeStr(-89)).toEqual('-00:00.1');
-  expect(millisToTimeStr(-890)).toEqual('-00:00.9');
-  expect(millisToTimeStr(-990)).toEqual('-00:01.0');
+  expect(millisToTimeStr(-89)).toEqual('-00:00.0');
+  expect(millisToTimeStr(-99)).toEqual('-00:00.0');
+  expect(millisToTimeStr(-100)).toEqual('-00:00.1');
+  expect(millisToTimeStr(-890)).toEqual('-00:00.8');
+  expect(millisToTimeStr(-990)).toEqual('-00:00.9');
+  expect(millisToTimeStr(-999)).toEqual('-00:00.9');
+  expect(millisToTimeStr(-1000)).toEqual('-00:01');
+  expect(millisToTimeStr(-1999)).toEqual('-00:01');
+  expect(millisToTimeStr(-2000)).toEqual('-00:02');
   expect(millisToTimeStr(-8900)).toEqual('-00:08');
   expect(millisToTimeStr(-10000)).toEqual('-00:10');
   expect(millisToTimeStr(-10300)).toEqual('-00:10');
@@ -20,4 +38,7 @@ it('tests millis to time', () => {
   expect(millisToTimeStr(-59000)).toEqual('-00:59');
   expect(millisToTimeStr(-59700)).toEqual('-00:59');
   expect(millisToTimeStr(-60000)).toEqual('-01:00');
+  expect(millisToTimeStr(-3599000)).toEqual('-59:59');
+  expect(millisToTimeStr(-3599999)).toEqual('-59:59');
+  expect(millisToTimeStr(-3600000)).toEqual('-60:00');
 });


### PR DESCRIPTION
Previously, the timer requested rerendering:
- in 500ms when there are more than 10 seconds.
- in 100ms when timer hasn't expired.
- very often once time expired. This is because `setTimeout` was called with negative delay.

While seconds were ceil'ed, deciseconds were rounded half-up; after `00:11` for 1 second, `00:10.0` was displayed for 0.05s, before `00:09.9` to `-00:00.9` for about 0.1s each, and then `-00:01.0` for 0.05s before switching back to `-00:01` for 1 second.

Deciseconds were also formatted with floating point (and `toFixed(1)`), which caused the string to change at 9950, 9850, 9749ms, ... -750, -851, -951ms.

This patch improves `scheduleTick` and `millisToTimeStr` so that deciseconds are ceil'ed too and rerendering happens less often:
- in 100ms when the timer is in (-1s, +10s]
- in 1s otherwise, including when the timer has expired.