### PR TITLE
fix space at edge

### DIFF
--- a/liwords-ui/src/utils/cwgame/tile_placement.ts
+++ b/liwords-ui/src/utils/cwgame/tile_placement.ts
@@ -215,6 +215,11 @@ export const handleKeyPress = (
     if (newcol > board.dim - 1) {
       newcol = board.dim - 1;
     }
+    if (ephTileMap[uniqueTileIdx(newrow, newcol)] !== undefined) {
+      // Just after placing a tile at the right or bottom edge,
+      // pressing Space should not place the newArrow on the tile.
+      return null;
+    }
     return {
       newArrow: {
         row: newrow,


### PR DESCRIPTION
Currently, just after placing a tile at the right or bottom edge (column O or row 15), pressing Space places the newArrow on the tile instead of keeping it after the tile.

By typing one tile at a time (and pressing Space between them), it is possible to stack multiple tiles on the same square.

<img width="421" alt="Screenshot 2020-10-14 at 01 48 14" src="https://user-images.githubusercontent.com/4179698/95897173-aef2e280-0dbf-11eb-967e-d19a2b1fe45a.png">

Also pressing Backspace after such a case would backspace the previous tile (column N or row 14) instead of the tile at the edge.