### PR TITLE
gcg support more usernames

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -85,7 +85,8 @@ const gcgExport = (gameID: string, playerMeta: Array<PlayerMetadata>) => {
       link.href = url;
       let downloadFilename = `${gameID}.gcg`;
       // TODO: allow more characters as applicable
-      if (playerMeta.every((x) => /^[0-9A-Za-z]+$/.test(x.nickname))) {
+      // Note: does not actively prevent saving .dotfiles or nul.something
+      if (playerMeta.every((x) => /^[-0-9A-Za-z_.]+$/.test(x.nickname))) {
         const byStarts: Array<Array<string>> = [[], []];
         for (const x of playerMeta) {
           byStarts[+!!x.first].push(x.nickname);


### PR DESCRIPTION
in #117 usernames were added to gcg files if they meet the validation criteria (since we don't want to create invalid filenames), which was just digits and letters.

in #126 support for `.`, `-`, `_` were added.

this allows newly supported usernames with those characters to also have their usernames in the gcg.

this also means pathological usernames like `.profile` (bad for linux/mac) and `nul.something` (bad for windows) should be prevented separately.

and both "`a-b` vs `c`" and "`a` vs `b-c`" would save as `a-b-c-gameid.gcg` 