### PR TITLE
do not type to search

### DIFF
--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -27,6 +27,7 @@ export const Chat = React.memo((props: Props) => {
   const el = useRef<HTMLDivElement>(null);
   const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
+      e.preventDefault();
       // Send if non-trivial
       const msg = curMsg.trim();
       setCurMsg('');

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -764,6 +764,11 @@ export const BoardPanel = React.memo((props: Props) => {
       keydown,
     ]
   );
+  // Just put this in onKeyPress to block all typeable keys so that typos from
+  // placing a tile not on rack also do not trigger type-to-find on firefox.
+  const preventFirefoxTypeToSearch = useCallback((e) => {
+    e.preventDefault();
+  }, []);
   const handlePass = useCallback(() => makeMove('pass'), [makeMove]);
   const handleResign = useCallback(() => makeMove('resign'), [makeMove]);
   const handleChallenge = useCallback(() => makeMove('challenge'), [makeMove]);
@@ -781,6 +786,7 @@ export const BoardPanel = React.memo((props: Props) => {
       id="board-container"
       className="board-container"
       onKeyDown={handleKeyDown}
+      onKeyPress={preventFirefoxTypeToSearch}
       tabIndex={-1}
       role="textbox"
     >

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -435,23 +435,28 @@ export const BoardPanel = React.memo((props: Props) => {
       }
       if (isMyTurn() && !props.gameDone) {
         if (key === '2') {
+          evt.preventDefault();
           makeMove('pass');
           return;
         }
         if (key === '3') {
+          evt.preventDefault();
           makeMove('challenge');
           return;
         }
         if (key === '4' && exchangeAllowed) {
+          evt.preventDefault();
           setExchangeModalVisible(true);
           return;
         }
         if (key === '$' && exchangeAllowed) {
+          evt.preventDefault();
           makeMove('exchange', props.currentRack);
           return;
         }
       }
       if (key === 'ArrowLeft' || key === 'ArrowRight') {
+        evt.preventDefault();
         setArrowProperties({
           ...arrowProperties,
           horizontal: !arrowProperties.horizontal,
@@ -459,14 +464,17 @@ export const BoardPanel = React.memo((props: Props) => {
         return;
       }
       if (key === 'ArrowDown') {
+        evt.preventDefault();
         recallTiles();
         return;
       }
       if (key === 'ArrowUp') {
+        evt.preventDefault();
         shuffleTiles();
         return;
       }
       if (key === EnterKey && !exchangeModalVisible && !blankModalVisible) {
+        evt.preventDefault();
         makeMove('commit');
         return;
       }
@@ -493,6 +501,7 @@ export const BoardPanel = React.memo((props: Props) => {
       if (handlerReturn === null) {
         return;
       }
+      evt.preventDefault();
       setDisplayedRack(handlerReturn.newDisplayedRack);
       setArrowProperties(handlerReturn.newArrow);
       setPlacedTiles(handlerReturn.newPlacedTiles);


### PR DESCRIPTION
"Firefox PC, type-ahead find interferes with typing onto the board"

apparently firefox has this thing in Preferences-General-Browsing, and it's making it painful to type to place tiles

<img width="298" alt="Screenshot 2020-10-16 at 21 18 44" src="https://user-images.githubusercontent.com/4179698/96263100-34130d00-0ff5-11eb-8511-ea1efb0c1564.png">
