### PR TITLE
use down arrow svg

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { Button, Modal, notification, message, Tooltip } from 'antd';
-import { SyncOutlined } from '@ant-design/icons';
+import { ArrowDownOutlined, SyncOutlined } from '@ant-design/icons';
 import axios from 'axios';
 
 import GameBoard from './board';
@@ -797,9 +797,12 @@ export const BoardPanel = React.memo((props: Props) => {
             mouseLeaveDelay={0.01}
             color={colors.colorPrimary}
           >
-            <Button shape="circle" type="primary" onClick={recallTiles}>
-              &#8595;
-            </Button>
+            <Button
+              shape="circle"
+              icon={<ArrowDownOutlined />}
+              type="primary"
+              onClick={recallTiles}
+            />
           </Tooltip>
           <Rack
             letters={displayedRack}


### PR DESCRIPTION
fixes #162 

old: (varies by OS/browser)

<img width="511" alt="Screenshot 2020-10-17 at 04 04 23" src="https://user-images.githubusercontent.com/4179698/96303943-df3fb880-102d-11eb-82a5-9c54a56b8088.png">

new:

<img width="526" alt="Screenshot 2020-10-17 at 04 00 03" src="https://user-images.githubusercontent.com/4179698/96303901-c9ca8e80-102d-11eb-88a7-cc8829a6bb44.png">
