### PR TITLE
remove gcg A

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -105,6 +105,7 @@ const gcgExport = (gameID: string, playerMeta: Array<PlayerMetadata>) => {
       link.setAttribute('download', downloadFilename);
       document.body.appendChild(link);
       link.onclick = () => {
+        link.remove();
         setTimeout(() => {
           window.URL.revokeObjectURL(url);
         }, 1000);


### PR DESCRIPTION
currently clicking export gcg n times creates n `<a>` elements and they're never removed