### PR TITLE
fix drag generating blank

### DIFF
--- a/liwords-ui/src/utils/cwgame/tile_placement.ts
+++ b/liwords-ui/src/utils/cwgame/tile_placement.ts
@@ -355,7 +355,11 @@ export const handleDroppedTile = (
   if (rackIndex > -1) {
     rune = unplacedTiles[rackIndex];
   } else {
-    rune = ephTileMap[tileIndex] ? ephTileMap[tileIndex].letter : '';
+    if (!(tileIndex in ephTileMap)) {
+      // Dragged tile no longer at source, likely because opponent moved there.
+      return null;
+    }
+    rune = ephTileMap[tileIndex].letter;
     newPlacedTiles.delete(ephTileMap[tileIndex]);
   }
 


### PR DESCRIPTION
this fixes the issue where the tile being dragged from the board "turns into a blank" when the board is reset. the reproduction steps are described in https://github.com/domino14/liwords/issues/153#issuecomment-711074140

in `handleDroppedTile` if the tile index is no longer valid, instead of doing nothing, it sets rune to `''`, and then proceeds to drop it:
https://github.com/domino14/liwords/blob/cbb14a7137d134f31e8121ec50b0f5e8b82c385c/liwords-ui/src/utils/cwgame/tile_placement.ts#L355-L367

unfortunately, because `isBlank` returns true for `''`, the dropped tile is transmogrified into `Blank`:
https://github.com/domino14/liwords/blob/cbb14a7137d134f31e8121ec50b0f5e8b82c385c/liwords-ui/src/utils/cwgame/common.ts#L24-L29

the premove feature did not introduce this issue, instead it made it less likely to happen (because instead of resetting the board when opponent moves, now it resets the board only when opponent's move affects the tentative play).

this does not fix the typing case https://github.com/domino14/liwords/issues/153#issuecomment-710696175 since there isn't reproduction info on that