### PR TITLE
Stability

### DIFF
--- a/cmd/convert-pb/main.go
+++ b/cmd/convert-pb/main.go
@@ -54,6 +54,8 @@ func main() {
 			pbmsg = &realtime.GameRequest{}
 		case "GameHistoryRefresher":
 			pbmsg = &realtime.GameHistoryRefresher{}
+		case "ServerGameplayEvent":
+			pbmsg = &realtime.ServerGameplayEvent{}
 		default:
 			panic("message " + *messageName + " not handled")
 		}

--- a/cmd/liwords-api/main.go
+++ b/cmd/liwords-api/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	_ "expvar"
 	"net/http"
 	"os"
 	"os/signal"

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -101,7 +101,7 @@ export const Table = React.memo((props: Props) => {
   const { rematchRequest, setRematchRequest } = useRematchRequestStoreContext();
   const { resetStore } = useResetStoreContext();
   const { pTimedOut, setPTimedOut } = useTimerStoreContext();
-  const { username } = loginState;
+  const { username, userID } = loginState;
 
   const { sendSocketMsg } = props;
   // const location = useLocation();
@@ -248,7 +248,7 @@ export const Table = React.memo((props: Props) => {
   useEffect(() => {
     let observer = true;
     gameInfo.players.forEach((p) => {
-      if (username === p.nickname) {
+      if (userID === p.user_id) {
         observer = false;
       }
     });
@@ -263,7 +263,7 @@ export const Table = React.memo((props: Props) => {
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [username, gameInfo]);
+  }, [userID, gameInfo]);
 
   const acceptRematch = useCallback(
     (reqID: string) => {
@@ -326,8 +326,8 @@ export const Table = React.memo((props: Props) => {
   let rack;
   const gameDone = gameInfo.game_end_reason !== 'NONE';
   const us = useMemo(
-    () => gameInfo.players.find((p) => p.nickname === username),
-    [gameInfo.players, username]
+    () => gameInfo.players.find((p) => p.user_id === userID),
+    [gameInfo.players, userID]
   );
   if (us && !(gameDone && isExamining)) {
     rack = examinableGameContext.players.find((p) => p.userID === us.user_id)

--- a/liwords-ui/src/store/socket_handlers.ts
+++ b/liwords-ui/src/store/socket_handlers.ts
@@ -400,7 +400,7 @@ export const useOnSocketMsg = () => {
 
           case MessageType.SERVER_GAMEPLAY_EVENT: {
             const sge = parsedMsg as ServerGameplayEvent;
-            console.log('got server event', sge);
+            console.log('got server event', sge.toObject());
             dispatchGameContext({
               actionType: ActionType.AddGameEvent,
               payload: sge,

--- a/pkg/gameplay/end.go
+++ b/pkg/gameplay/end.go
@@ -87,7 +87,9 @@ func performEndgameDuties(ctx context.Context, g *entity.Game, gameStore GameSto
 	for _, sge := range evts {
 		wrapped := entity.WrapEvent(sge, pb.MessageType_SERVER_GAMEPLAY_EVENT)
 		wrapped.AddAudience(entity.AudGameTV, g.GameID())
-		wrapped.AddAudience(entity.AudGame, g.GameID())
+		for _, p := range players(g) {
+			wrapped.AddAudience(entity.AudUser, p+".game."+g.GameID())
+		}
 		g.SendChange(wrapped)
 		g.History().Events = append(g.History().Events, sge.Event)
 	}

--- a/pkg/stores/game/cache.go
+++ b/pkg/stores/game/cache.go
@@ -77,6 +77,12 @@ func NewCache(backing backingStore) *Cache {
 // Unload unloads the game from the cache
 func (c *Cache) Unload(ctx context.Context, id string) {
 	c.cache.Remove(id)
+	// Let's also expire the active games cache. The only time we ever
+	// call Unload is when a game is over - so we don't want to go back
+	// to the lobby and still show our game as active.
+	c.Lock()
+	defer c.Unlock()
+	c.activeGamesLastUpdated = time.Time{}
 }
 
 // SetGameEventChan sets the game event channel to the passed in channel.


### PR DESCRIPTION
- Fix scoring bug (#82). Game end events were being sent out of order (sometimes) because they were sent to different channels (user channels vs game channels for the overtime events) at nearly the same time. NATS probably did something funky there. Send events to the same channel to queue them up and receive them in order.
- Invalidate active games cache (#178) when a game ends.