### PR TITLE
improve keyboard handling

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -130,7 +130,11 @@ const gcgExport = (gameID: string, playerMeta: Array<PlayerMetadata>) => {
 export const BoardPanel = React.memo((props: Props) => {
   const { useState } = useMountedState();
 
-  const [drawingKeyMode, setDrawingKeyMode] = useState(false);
+  // Poka-yoke against accidentally having multiple modes active.
+  const [currentMode, setCurrentMode] = useState<
+    'BLANK_MODAL' | 'DRAWING_HOTKEY' | 'EXCHANGE_MODAL' | 'NORMAL'
+  >('NORMAL');
+
   const {
     drawingCanBeEnabled,
     handleKeyDown: handleDrawingKeyDown,
@@ -147,7 +151,6 @@ export const BoardPanel = React.memo((props: Props) => {
   const [placedTilesTempScore, setPlacedTilesTempScore] = useState<
     number | undefined
   >(undefined);
-  const [blankModalVisible, setBlankModalVisible] = useState(false);
   const {
     gameContext: examinableGameContext,
   } = useExaminableGameContextStoreContext();
@@ -157,7 +160,6 @@ export const BoardPanel = React.memo((props: Props) => {
   const { isExamining, handleExamineStart } = useExamineStoreContext();
   const { gameContext } = useGameContextStoreContext();
   const { stopClock } = useTimerStoreContext();
-  const [exchangeModalVisible, setExchangeModalVisible] = useState(false);
   const [exchangeAllowed, setexchangeAllowed] = useState(true);
 
   const observer = !props.playerMeta.some((p) => p.nickname === props.username);
@@ -469,7 +471,7 @@ export const BoardPanel = React.memo((props: Props) => {
         }
         if (key === '4' && exchangeAllowed) {
           evt.preventDefault();
-          setExchangeModalVisible(true);
+          setCurrentMode('EXCHANGE_MODAL');
           return;
         }
         if (key === '$' && exchangeAllowed) {
@@ -496,12 +498,12 @@ export const BoardPanel = React.memo((props: Props) => {
         shuffleTiles();
         return;
       }
-      if (key === EnterKey && !exchangeModalVisible && !blankModalVisible) {
+      if (key === EnterKey && currentMode === 'NORMAL') {
         evt.preventDefault();
         makeMove('commit');
         return;
       }
-      if (exchangeModalVisible) {
+      if (currentMode === 'EXCHANGE_MODAL') {
         return;
       }
       if (!arrowProperties.show) {
@@ -532,10 +534,9 @@ export const BoardPanel = React.memo((props: Props) => {
     },
     [
       arrowProperties,
-      blankModalVisible,
+      currentMode,
       displayedRack,
       exchangeAllowed,
-      exchangeModalVisible,
       isMyTurn,
       makeMove,
       placedTiles,
@@ -571,7 +572,7 @@ export const BoardPanel = React.memo((props: Props) => {
       setPlacedTilesTempScore(handlerReturn.playScore);
       setArrowProperties({ row: 0, col: 0, horizontal: false, show: false });
       if (handlerReturn.isUndesignated) {
-        setBlankModalVisible(true);
+        setCurrentMode('BLANK_MODAL');
       }
     },
     [displayedRack, placedTiles, props.board]
@@ -602,7 +603,7 @@ export const BoardPanel = React.memo((props: Props) => {
       setPlacedTiles(handlerReturn.newPlacedTiles);
       setPlacedTilesTempScore(handlerReturn.playScore);
       if (handlerReturn.isUndesignated) {
-        setBlankModalVisible(true);
+        setCurrentMode('BLANK_MODAL');
       }
       let newrow = arrowProperties.row;
       let newcol = arrowProperties.col;
@@ -644,7 +645,7 @@ export const BoardPanel = React.memo((props: Props) => {
 
   const handleBoardTileClick = useCallback((rune: string) => {
     if (rune === Blank) {
-      setBlankModalVisible(true);
+      setCurrentMode('BLANK_MODAL');
     }
   }, []);
 
@@ -659,7 +660,7 @@ export const BoardPanel = React.memo((props: Props) => {
       if (handlerReturn === null) {
         return;
       }
-      setBlankModalVisible(false);
+      setCurrentMode('NORMAL');
       setPlacedTiles(handlerReturn.newPlacedTiles);
       setPlacedTilesTempScore(handlerReturn.playScore);
     },
@@ -667,7 +668,7 @@ export const BoardPanel = React.memo((props: Props) => {
   );
 
   const handleBlankModalCancel = useCallback(() => {
-    setBlankModalVisible(false);
+    setCurrentMode('NORMAL');
   }, []);
 
   const returnToRack = useCallback(
@@ -704,12 +705,12 @@ export const BoardPanel = React.memo((props: Props) => {
   );
 
   const showExchangeModal = useCallback(() => {
-    setExchangeModalVisible(true);
+    setCurrentMode('EXCHANGE_MODAL');
   }, []);
 
   const handleExchangeModalOk = useCallback(
     (exchangedTiles: string) => {
-      setExchangeModalVisible(false);
+      setCurrentMode('NORMAL');
       makeMove('exchange', exchangedTiles);
     },
     [makeMove]
@@ -748,18 +749,18 @@ export const BoardPanel = React.memo((props: Props) => {
     (e) => {
       if (drawingCanBeEnabled) {
         // To activate a drawing hotkey, type 0, then the hotkey.
-        if (!exchangeModalVisible && !blankModalVisible) {
+        if (currentMode === 'NORMAL' || currentMode === 'DRAWING_HOTKEY') {
           if (e.ctrlKey || e.altKey || e.metaKey) {
             // Do not prevent Ctrl+0/Cmd+0.
           } else {
-            if (drawingKeyMode) {
+            if (currentMode === 'DRAWING_HOTKEY') {
               e.preventDefault();
-              setDrawingKeyMode(false);
+              setCurrentMode('NORMAL');
               handleDrawingKeyDown(e);
               return;
             } else if (e.key === '0') {
               e.preventDefault();
-              setDrawingKeyMode(true);
+              setCurrentMode('DRAWING_HOTKEY');
               console.log(
                 'You pressed 0. Now press one of these keys:' +
                   '\n0 = Toggle drawing' +
@@ -786,14 +787,7 @@ export const BoardPanel = React.memo((props: Props) => {
       }
       keydown(e);
     },
-    [
-      blankModalVisible,
-      drawingCanBeEnabled,
-      drawingKeyMode,
-      exchangeModalVisible,
-      handleDrawingKeyDown,
-      keydown,
-    ]
+    [currentMode, drawingCanBeEnabled, handleDrawingKeyDown, keydown]
   );
   // Just put this in onKeyPress to block all typeable keys so that typos from
   // placing a tile not on rack also do not trigger type-to-find on firefox.
@@ -809,7 +803,7 @@ export const BoardPanel = React.memo((props: Props) => {
     [props.gameID, props.playerMeta]
   );
   const handleExchangeTilesCancel = useCallback(() => {
-    setExchangeModalVisible(false);
+    setCurrentMode('NORMAL');
   }, []);
 
   return (
@@ -899,14 +893,14 @@ export const BoardPanel = React.memo((props: Props) => {
       />
       <ExchangeTiles
         rack={props.currentRack}
-        modalVisible={exchangeModalVisible}
+        modalVisible={currentMode === 'EXCHANGE_MODAL'}
         onOk={handleExchangeModalOk}
         onCancel={handleExchangeTilesCancel}
       />
       <Modal
         className="blank-modal"
         title="Designate your blank"
-        visible={blankModalVisible}
+        visible={currentMode === 'BLANK_MODAL'}
         onCancel={handleBlankModalCancel}
         width={360}
         footer={null}

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -504,8 +504,6 @@ export const BoardPanel = React.memo((props: Props) => {
           makeMove('commit');
           return;
         }
-      }
-      if (currentMode === 'NORMAL' || currentMode === 'BLANK_MODAL') {
         if (key === '?') {
           return;
         }

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -506,9 +506,6 @@ export const BoardPanel = React.memo((props: Props) => {
         }
       }
       if (currentMode === 'NORMAL' || currentMode === 'BLANK_MODAL') {
-        if (!arrowProperties.show) {
-          return;
-        }
         if (key === '?') {
           return;
         }

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -458,79 +458,80 @@ export const BoardPanel = React.memo((props: Props) => {
           key = key.toUpperCase();
         }
       }
-      if (isMyTurn() && !props.gameDone) {
-        if (key === '2') {
+      if (currentMode === 'NORMAL') {
+        if (isMyTurn() && !props.gameDone) {
+          if (key === '2') {
+            evt.preventDefault();
+            makeMove('pass');
+            return;
+          }
+          if (key === '3') {
+            evt.preventDefault();
+            makeMove('challenge');
+            return;
+          }
+          if (key === '4' && exchangeAllowed) {
+            evt.preventDefault();
+            setCurrentMode('EXCHANGE_MODAL');
+            return;
+          }
+          if (key === '$' && exchangeAllowed) {
+            evt.preventDefault();
+            makeMove('exchange', props.currentRack);
+            return;
+          }
+        }
+        if (key === 'ArrowLeft' || key === 'ArrowRight') {
           evt.preventDefault();
-          makeMove('pass');
+          setArrowProperties({
+            ...arrowProperties,
+            horizontal: !arrowProperties.horizontal,
+          });
           return;
         }
-        if (key === '3') {
+        if (key === 'ArrowDown') {
           evt.preventDefault();
-          makeMove('challenge');
+          recallTiles();
           return;
         }
-        if (key === '4' && exchangeAllowed) {
+        if (key === 'ArrowUp') {
           evt.preventDefault();
-          setCurrentMode('EXCHANGE_MODAL');
+          shuffleTiles();
           return;
         }
-        if (key === '$' && exchangeAllowed) {
+        if (key === EnterKey) {
           evt.preventDefault();
-          makeMove('exchange', props.currentRack);
+          makeMove('commit');
           return;
         }
       }
-      if (key === 'ArrowLeft' || key === 'ArrowRight') {
-        evt.preventDefault();
-        setArrowProperties({
-          ...arrowProperties,
-          horizontal: !arrowProperties.horizontal,
-        });
-        return;
-      }
-      if (key === 'ArrowDown') {
-        evt.preventDefault();
-        recallTiles();
-        return;
-      }
-      if (key === 'ArrowUp') {
-        evt.preventDefault();
-        shuffleTiles();
-        return;
-      }
-      if (key === EnterKey && currentMode === 'NORMAL') {
-        evt.preventDefault();
-        makeMove('commit');
-        return;
-      }
-      if (currentMode === 'EXCHANGE_MODAL') {
-        return;
-      }
-      if (!arrowProperties.show) {
-        return;
-      }
-      if (key === '?') {
-        return;
-      }
-      // This should return a new set of arrow properties, and also set
-      // some state further up (the tiles layout with a "just played" type
-      // marker)
-      const handlerReturn = handleKeyPress(
-        arrowProperties,
-        props.board,
-        key,
-        displayedRack,
-        placedTiles
-      );
+      if (currentMode === 'NORMAL' || currentMode === 'BLANK_MODAL') {
+        if (!arrowProperties.show) {
+          return;
+        }
+        if (key === '?') {
+          return;
+        }
+        // This should return a new set of arrow properties, and also set
+        // some state further up (the tiles layout with a "just played" type
+        // marker)
+        const handlerReturn = handleKeyPress(
+          arrowProperties,
+          props.board,
+          key,
+          displayedRack,
+          placedTiles
+        );
 
-      if (handlerReturn === null) {
-        return;
+        if (handlerReturn === null) {
+          return;
+        }
+        evt.preventDefault();
+        setDisplayedRack(handlerReturn.newDisplayedRack);
+        setArrowProperties(handlerReturn.newArrow);
+        setPlacedTiles(handlerReturn.newPlacedTiles);
+        setPlacedTilesTempScore(handlerReturn.playScore);
       }
-      evt.preventDefault();
-      setDisplayedRack(handlerReturn.newDisplayedRack);
-      setArrowProperties(handlerReturn.newArrow);
-      setPlacedTiles(handlerReturn.newPlacedTiles);
-      setPlacedTilesTempScore(handlerReturn.playScore);
     },
     [
       arrowProperties,

--- a/liwords-ui/src/gameroom/exchange_tiles.tsx
+++ b/liwords-ui/src/gameroom/exchange_tiles.tsx
@@ -34,6 +34,15 @@ export const ExchangeTiles = React.memo((props: Props) => {
 
   const propsOnOk = props.onOk;
 
+  // Temporary message until UI shows it.
+  useEffect(() => {
+    if (props.modalVisible) {
+      console.log(
+        'When exchanging, press - to toggle the tiles selected. For example, type 4 E - Enter to exchange 6 and keep E.'
+      );
+    }
+  }, [props.modalVisible]);
+
   const keydown = useCallback(
     (e: KeyboardEvent) => {
       if (delayInput || !props.modalVisible) {

--- a/liwords-ui/src/utils/cwgame/tile_placement.ts
+++ b/liwords-ui/src/utils/cwgame/tile_placement.ts
@@ -141,6 +141,7 @@ export const handleKeyPress = (
 
   // Make sure we're not trying to type off the edge of the board.
   if (
+    !arrowProperty.show ||
     arrowProperty.row >= board.dim ||
     arrowProperty.col >= board.dim ||
     arrowProperty.row < 0 ||


### PR DESCRIPTION
previously there can be confusion between different modes. making it very clear in code that only one mode can be active (normal mode, blank modal mode, exchange modal mode, "drawing hotkey" mode).

previously shortcuts like 2, 3, 4, $ were handled in other modes (leading to inadvertent passes while exchange modal is open, for example). now restricting this to normal mode.

previously backspace was broken (again) when the placement arrow is not visible past row 15 or column O. fixing that.

previously typing a letter while blank modal is open placed that into the next spot. changing it so it does nothing now (need to esc out of the blank modal in order to continue typing).

previously the `-` hotkey while exchanging, introduced in #183, wasn't advertised. adding console.log until it's figured out how to present it in ui.

this pull request is best reviewed commit-by-commit with ignore-whitespace option.