### PR TITLE
support drag to gap between tiles on rack

### DIFF
--- a/liwords-ui/src/gameroom/tile.tsx
+++ b/liwords-ui/src/gameroom/tile.tsx
@@ -110,23 +110,23 @@ const Tile = React.memo((props: TileProps) => {
     props.lastPlayed ? ' last-played' : ''
   }${isDesignatedBlank(props.rune) ? ' blank' : ''}`;
   return (
-    <div
-      className={computedClassName}
-      data-rune={props.rune}
-      style={{ cursor: props.grabbable ? 'grab' : 'default' }}
-      onClick={props.onClick}
-      onDragStart={handleStartDrag}
-      onDragEnd={handleEndDrag}
-      onDragOver={handleDropOver}
-      onDrop={handleDrop}
-      draggable={props.grabbable}
-    >
-      <TileLetter rune={props.rune} />
-      <PointValue value={props.value} />
-      <TentativeScore
-        score={props.tentativeScore}
-        horizontal={props.tentativeScoreIsHorizontal}
-      />
+    <div onDragOver={handleDropOver} onDrop={handleDrop}>
+      <div
+        className={computedClassName}
+        data-rune={props.rune}
+        style={{ cursor: props.grabbable ? 'grab' : 'default' }}
+        onClick={props.onClick}
+        onDragStart={handleStartDrag}
+        onDragEnd={handleEndDrag}
+        draggable={props.grabbable}
+      >
+        <TileLetter rune={props.rune} />
+        <PointValue value={props.value} />
+        <TentativeScore
+          score={props.tentativeScore}
+          horizontal={props.tentativeScoreIsHorizontal}
+        />
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
the tiles on the rack has a margin, previously dragging to that margin wasn't working.

https://github.com/domino14/liwords/blob/eab06f5eaa6d7ef1ef69a2c6061242796958490e/liwords-ui/src/gameroom/scss/gameroom.scss#L413-L416