### PR TITLE
style scorecard avatar

### DIFF
--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -21,6 +21,7 @@ type Props = {
 };
 
 type turnProps = {
+  playerMeta: Array<PlayerMetadata>;
   playing: boolean;
   username: string;
   turn: Turn;
@@ -113,9 +114,10 @@ const ScorecardTurn = (props: turnProps) => {
     ) {
       timeRemaining = millisToTimeStr(evts[0].getMillisRemaining(), false);
     }
-
     const turn = {
-      player: {
+      player: props.playerMeta.find(
+        (playerMeta) => playerMeta.nickname === evts[0].getNickname()
+      ) ?? {
         nickname: evts[0].getNickname(),
         // XXX: FIX THIS. avatar url should be set.
         full_name: '',
@@ -178,7 +180,7 @@ const ScorecardTurn = (props: turnProps) => {
     }
     return turn;
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.turn]);
+  }, [props.playerMeta, props.turn]);
 
   let scoreChange;
   if (memoizedTurn.lostScore > 0) {
@@ -316,6 +318,7 @@ export const ScoreCard = React.memo((props: Props) => {
                 turn={t}
                 board={props.board}
                 key={`t_${idx + 0}`}
+                playerMeta={props.playerMeta}
                 playing={props.playing}
                 username={props.username}
               />

--- a/liwords-ui/src/shared/player_avatar.tsx
+++ b/liwords-ui/src/shared/player_avatar.tsx
@@ -13,6 +13,12 @@ type AvatarProps = {
 export const PlayerAvatar = (props: AvatarProps) => {
   let avatarStyle = {};
 
+  if (props.player?.first) {
+    avatarStyle = {
+      transform: 'rotate(-10deg)',
+    };
+  }
+
   // XXX temporary code!
   if (props.player?.is_bot) {
     // eslint-disable-next-line no-param-reassign


### PR DESCRIPTION
- support avatars when it is ready
- (for now, make bot avatar work on scorecard)
- apply woogles-tilt for player1 initial-as-avatar for now so that players with the same initials can be distinguished

<img width="69" alt="Screenshot 2020-10-23 at 22 45 55" src="https://user-images.githubusercontent.com/4179698/97018281-8ddd7f00-1581-11eb-926f-2be3c58de7fa.png">
