### PR TITLE
sync avatar font size

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -632,7 +632,7 @@
     width: 36px;
     min-width: 36px;
     height: 36px;
-    font-size: 24px;
+    font-size: 27px;
   }
 
   .turn {

--- a/liwords-ui/src/gameroom/scss/playerCards.scss
+++ b/liwords-ui/src/gameroom/scss/playerCards.scss
@@ -138,7 +138,7 @@
           width: 40px;
           min-width: 40px;
           height: 40px;
-          font-size: 20px;
+          font-size: 30px;
         }
       }
 


### PR DESCRIPTION
`.player-avatar` is defined 4x in css
- 24px font in 36x36 (2/3)
- 36px font in 48x48 (3/4)
- 20px font in 40x40 (2/4)
- 36px font in 48x48 (3/4) again

this is just to make them consistent, so
- **27px** font in 36x36 (3/4)
- 36px font in 48x48 (3/4)
- **30px** font in 40x40 (3/4)
- 36px font in 48x48 (3/4) again
