### PR TITLE
fix zero score when moving rack tile

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -757,7 +757,6 @@ export const BoardPanel = React.memo((props: Props) => {
         const newRack = displayedRack.split('');
         newRack.splice(oldIndex, 1);
         newRack.splice(newIndex, 0, displayedRack[oldIndex]);
-        setPlacedTilesTempScore(0);
         setDisplayedRack(newRack.join(''));
       }
     },


### PR DESCRIPTION
currently
1. place a few tiles, keeping at least one tile on rack
2. drag a tile from rack to rack (you can even put it at the same position, or drag it to the empty space next to it)
3. observe the tentative score

the tentative score becomes zero.

this fixes it