### PR TITLE
improve shuffle

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -73,12 +73,35 @@ const shuffleString = (a: string): string => {
   const alist = a.split('');
   const n = a.length;
 
+  let somethingChanged = false;
   for (let i = n - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
-    const tmp = alist[i];
-    alist[i] = alist[j];
-    alist[j] = tmp;
+    if (alist[i] !== alist[j]) {
+      somethingChanged = true;
+      const tmp = alist[i];
+      alist[i] = alist[j];
+      alist[j] = tmp;
+    }
   }
+
+  if (!somethingChanged) {
+    // Let's change something if possible.
+    const j = Math.floor(Math.random() * n);
+    let x = [];
+    for (let i = 0; i < n; ++i) {
+      if (alist[i] !== alist[j]) {
+        x.push(i);
+      }
+    }
+
+    if (x.length > 0) {
+      const i = x[Math.floor(Math.random() * x.length)];
+      const tmp = alist[i];
+      alist[i] = alist[j];
+      alist[j] = tmp;
+    }
+  }
+
   return alist.join('');
 };
 

--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -318,10 +318,8 @@ export const BoardPanel = React.memo((props: Props) => {
   ]);
 
   const shuffleTiles = useCallback(() => {
-    setPlacedTilesTempScore(0);
-    setPlacedTiles(new Set<EphemeralTile>());
-    setDisplayedRack(shuffleString(props.currentRack));
-  }, [props.currentRack]);
+    setDisplayedRack((displayedRack) => shuffleString(displayedRack));
+  }, []);
 
   const lastLettersRef = useRef<string>();
   const readOnlyEffectDependenciesRef = useRef<{


### PR DESCRIPTION
currently
- shuffling recalls all tiles
- there is a small chance that shuffling is a no-op because all possibilities are equally possible

proposed
- shuffling only shuffles the tiles still on rack (it's still possible to recall-and-shuffle: hit down arrow and then up arrow)
- when there are at least two distinct tiles on rack, shuffling should always generate a different order (even if the possibilities are no longer equal)