### PR TITLE
replace turn param

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -444,7 +444,7 @@ export const Table = React.memo((props: Props) => {
       } else {
         searchParams.set('turn', turnParamShouldBe);
       }
-      history.push({
+      history.replace({
         ...location,
         search: String(searchParams),
       });


### PR DESCRIPTION
#165 suggested that the `?turn=` autocorrection should replace history. #170 pushed to it instead.