### PR TITLE
improve notepad taking

### DIFF
--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -24,7 +24,7 @@ const humanReadablePosition = (
 ): string => {
   const readableCol = String.fromCodePoint(firstLetter.col + 65);
   const readableRow = (firstLetter.row + 1).toString();
-  if (direction === 1) {
+  if (direction === Direction.Horizontal) {
     return readableRow + readableCol;
   }
   return readableCol + readableRow;

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -51,9 +51,22 @@ export const Notepad = React.memo((props: NotepadProps) => {
         contiguousTiles[1],
         contiguousTiles[0][0]
       );
-      play = contiguousTiles[0]
-        .map((tile) => (tile.fresh ? tile.letter : `(${tile.letter})`))
-        .join('');
+      let inParen = false;
+      for (const tile of contiguousTiles[0]) {
+        if (!tile.fresh) {
+          if (!inParen) {
+            play += '(';
+            inParen = true;
+          }
+        } else {
+          if (inParen) {
+            play += ')';
+            inParen = false;
+          }
+        }
+        play += tile.letter;
+      }
+      if (inParen) play += ')';
     }
     setCurNotepad(
       `${curNotepad ? curNotepad + '\n' : ''}${

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -52,9 +52,7 @@ export const Notepad = React.memo((props: NotepadProps) => {
         contiguousTiles[0][0]
       );
       play = contiguousTiles[0]
-        .map((tile) =>
-          tile.fresh ? tile.letter : `(${tile.letter.toLowerCase()})`
-        )
+        .map((tile) => (tile.fresh ? tile.letter : `(${tile.letter})`))
         .join('');
     }
     setCurNotepad(


### PR DESCRIPTION
about the new feature in #227 

- the coordinates are inverted
- the played-through tiles should not be lowercased unless they are blanks
- consecutive parentheses should be merged

i.e.
`A4 (v)(i)(t)(a)(l)(i)(s)(e)D 24 EFRSTU`
should have been
`4A (VITAlISE)D 24 EFRSTU`

<img width="1301" alt="Screenshot 2020-11-01 at 12 47 09" src="https://user-images.githubusercontent.com/4179698/97795397-b3811d00-1c40-11eb-83d8-1f61c806a8eb.png">
