### PR TITLE
improve analyzer ux

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -5,7 +5,6 @@ import {
   useExaminableGameContextStoreContext,
   useTentativeTileContext,
 } from '../store/store';
-import { Unrace } from '../utils/unrace';
 import { getMacondo } from '../wasm/loader';
 import { useMountedState } from '../utils/mounted';
 import { RedoOutlined } from '@ant-design/icons/lib';
@@ -16,36 +15,6 @@ type AnalyzerProps = {
   style?: React.CSSProperties;
   lexicon: string;
 };
-
-const filesByLexicon = [
-  {
-    lexicons: ['CSW19', 'NWL18'],
-    cacheKey: 'data/letterdistributions/english.csv',
-    path: '/wasm/english.csv',
-  },
-  {
-    lexicons: ['CSW19', 'NWL18'],
-    cacheKey: 'data/strategy/default_english/leaves.idx',
-    path: '/wasm/leaves.idx',
-  },
-  {
-    lexicons: ['CSW19', 'NWL18'],
-    cacheKey: 'data/strategy/default_english/preendgame.json',
-    path: '/wasm/preendgame.json',
-  },
-  {
-    lexicons: ['CSW19'],
-    cacheKey: 'data/lexica/gaddag/CSW19.gaddag',
-    path: '/wasm/CSW19.gaddag',
-  },
-  {
-    lexicons: ['NWL18'],
-    cacheKey: 'data/lexica/gaddag/NWL18.gaddag',
-    path: '/wasm/NWL18.gaddag',
-  },
-];
-
-const unrace = new Unrace();
 
 // See analyzer/analyzer.go JsonMove.
 type JsonMove = {
@@ -192,15 +161,7 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
       };
 
       const macondo = await getMacondo();
-      await unrace.run(() =>
-        Promise.all(
-          filesByLexicon.map(({ lexicons, cacheKey, path }) =>
-            lexicons.includes(lexicon)
-              ? macondo.precache(cacheKey, path.toString())
-              : null
-          )
-        )
-      );
+      await macondo.loadLexicon(lexicon);
 
       const boardStr = JSON.stringify(boardObj);
       const movesStr = await macondo.analyze(boardStr);

--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Button, Card } from 'antd';
 import { BulbOutlined } from '@ant-design/icons';
 import {
@@ -115,11 +115,12 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     setPlacedTilesTempScore,
   } = useTentativeTileContext();
 
+  const examinerId = useRef(0);
+
   useEffect(() => {
-    if (moves.length > 0) {
-      setExaminerLoading(false);
-    }
-  }, [moves, setMoves, examinerLoading, setExaminerLoading]);
+    setExaminerLoading(false);
+    examinerId.current = (examinerId.current + 1) | 0;
+  }, [moves]);
 
   const placeMove = useCallback(
     (move) => {
@@ -177,6 +178,7 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     if (examinerLoading) {
       return;
     }
+    const examinerIdAtStart = examinerId.current;
     (async () => {
       const {
         board: { dim, letters },
@@ -194,10 +196,13 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
       };
 
       const macondo = await getMacondo();
+      if (examinerIdAtStart !== examinerId.current) return;
       await macondo.loadLexicon(lexicon);
+      if (examinerIdAtStart !== examinerId.current) return;
 
       const boardStr = JSON.stringify(boardObj);
       const movesStr = await macondo.analyze(boardStr);
+      if (examinerIdAtStart !== examinerId.current) return;
       const movesObj = JSON.parse(movesStr) as Array<JsonMove>;
 
       const formattedMoves = movesObj.map((move) =>
@@ -209,7 +214,7 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
 
   useEffect(() => {
     setMoves(new Array<AnalyzerMove>());
-  }, [examinableGameContext.lastPlayedTiles, setMoves]);
+  }, [examinableGameContext.lastPlayedTiles]);
 
   const renderAnalyzerMoves = useMemo(
     () =>

--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import { Button, Card } from 'antd';
 import { BulbOutlined } from '@ant-design/icons';
 import {
@@ -217,20 +217,25 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     setMoves(new Array<AnalyzerMove>());
   }, [examinableGameContext.lastPlayedTiles, setMoves]);
 
-  const renderAnalyzerMoves = moves.map((m: AnalyzerMove, idx) => (
-    <tr
-      key={idx}
-      onClick={() => {
-        placeMove(m);
-      }}
-    >
-      <td className="move-coords">{m.coordinates}</td>
-      <td className="move">{m.displayMove}</td>
-      <td className="move-score">{m.score}</td>
-      <td className="move-leave">{m.leave}</td>
-      <td className="move-equity">{m.equity}</td>
-    </tr>
-  ));
+  const renderAnalyzerMoves = useMemo(
+    () =>
+      moves.map((m: AnalyzerMove, idx) => (
+        <tr
+          key={idx}
+          onClick={() => {
+            placeMove(m);
+          }}
+        >
+          <td className="move-coords">{m.coordinates}</td>
+          <td className="move">{m.displayMove}</td>
+          <td className="move-score">{m.score}</td>
+          <td className="move-leave">{m.leave}</td>
+          <td className="move-equity">{m.equity}</td>
+        </tr>
+      )),
+    [moves, placeMove]
+  );
+
   const analyzerContainer = (
     <div className="analyzer-container">
       {!examinerLoading ? (

--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -212,9 +212,11 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     })();
   }, [examinableGameContext, lexicon, examinerLoading]);
 
+  // When at the last move, examineStoreContext.examinedTurn === Infinity.
+  // To also detect new moves, we use examinableGameContext.turns.length.
   useEffect(() => {
     setMoves(new Array<AnalyzerMove>());
-  }, [examinableGameContext.lastPlayedTiles]);
+  }, [examinableGameContext.turns.length]);
 
   const renderAnalyzerMoves = useMemo(
     () =>

--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -217,9 +217,9 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     setMoves(new Array<AnalyzerMove>());
   }, [examinableGameContext.lastPlayedTiles, setMoves]);
 
-  const renderAnalyzerMoves = moves.map((m: AnalyzerMove) => (
+  const renderAnalyzerMoves = moves.map((m: AnalyzerMove, idx) => (
     <tr
-      key={`${m.coordinates}${m.tiles}${m.vertical}`}
+      key={idx}
       onClick={() => {
         placeMove(m);
       }}

--- a/liwords-ui/src/gameroom/tile.tsx
+++ b/liwords-ui/src/gameroom/tile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useMountedState } from '../utils/mounted';
 import { useDrag, useDragLayer } from 'react-dnd';
 import TentativeScore from './tentative_score';
@@ -43,6 +43,7 @@ type TilePreviewProps = {
 };
 
 export const TilePreview = React.memo((props: TilePreviewProps) => {
+  const { useState } = useMountedState();
   const [updateCount, setUpdateCount] = useState(0);
   const { isDragging, xyPosition, initialPosition, rune, value } = useDragLayer(
     (monitor) => ({


### PR DESCRIPTION
improves #240 with
- some code quality improvements
- avoid placing exchanged tiles on existing tiles (tiles from rack vanished if there's a tile at 1A)
- prevent showing analysis for a different turn (race condition)

removing the extra zero moves relies on macondo not returning them: https://github.com/domino14/macondo/pull/109