### PR TITLE
allow examining first rack in most cases

### DIFF
--- a/liwords-ui/src/store/reducers/game_reducer.ts
+++ b/liwords-ui/src/store/reducers/game_reducer.ts
@@ -273,17 +273,14 @@ export const pushTurns = (gs: GameState, events: Array<GameEvent>) => {
   });
 };
 
-const stateFromHistory = (
-  history: GameHistory,
-  allowFlip: boolean
-): GameState => {
+const stateFromHistory = (history: GameHistory): GameState => {
   // XXX: Do this for now. We will eventually want to put the tile
   // distribution itself in the history protobuf.
   // if (['NWL18', 'CSW19'].includes(history!.getLexicon())) {
   //   const dist = EnglishCrosswordGameDistribution;
   // }
   let playerList = history.getPlayersList();
-  const flipPlayers = allowFlip && history.getSecondWentFirst();
+  const flipPlayers = history.getSecondWentFirst();
   // If flipPlayers is on, we want to flip the players in the playerList.
   // The backend doesn't do this because of Reasons.
   if (flipPlayers) {
@@ -488,7 +485,7 @@ export const GameReducer = (state: GameState, action: Action): GameState => {
 
     case ActionType.RefreshHistory: {
       const ghr = action.payload as GameHistoryRefresher;
-      const newState = stateFromHistory(ghr.getHistory()!, true);
+      const newState = stateFromHistory(ghr.getHistory()!);
 
       if (state.clockController !== null) {
         newState.clockController = state.clockController;
@@ -504,8 +501,7 @@ export const GameReducer = (state: GameState, action: Action): GameState => {
       // already been set. This can happen if it ends in an "abnormal" way
       // like a resignation or a timeout -- these aren't ServerGamePlayEvents per se.
       const gee = action.payload as GameEndedEvent;
-      // This "fixes" examining first rack, but breaks no-move case.
-      const newState = stateFromHistory(gee.getHistory()!, false);
+      const newState = stateFromHistory(gee.getHistory()!);
       if (newState.clockController) {
         newState.clockController.current?.stopClock();
       }

--- a/pkg/gameplay/end.go
+++ b/pkg/gameplay/end.go
@@ -147,7 +147,6 @@ func performEndgameDuties(ctx context.Context, g *entity.Game, gameStore GameSto
 		wrapped.AddAudience(entity.AudUser, p+".game."+g.GameID())
 	}
 	wrapped.AddAudience(entity.AudGameTV, g.GameID())
-	g.SendChange(wrapped)
 
 	// Compute stats for the player and for the game.
 	variantKey, err := g.RatingKey()
@@ -162,6 +161,10 @@ func performEndgameDuties(ctx context.Context, g *entity.Game, gameStore GameSto
 			g.Stats = gameStats
 		}
 	}
+
+	// Send the event here instead of above the computation of Game Stats
+	// to avoid race conditions (computeGameStats modifies the history).
+	g.SendChange(wrapped)
 
 	// Send a notification to the lobby that this
 	// game ended. This will remove it from the list of live games.


### PR DESCRIPTION
this seems to fix most of #239 and #196 cases.

unfortunately, why this fix works is more mysterious than the symptom itself.

there is an unrelated bug with examining the _last_ turn (for example, when a game is resigned), where it examines the opponent's rack until we refresh the page. when a game is resigned on the first turn, the first turn is the last turn.

this fix does not patch that case, so the first rack is incorrect in that case.