### PR TITLE
separate startgameSound

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -249,7 +249,6 @@ export const Table = React.memo((props: Props) => {
           setGameEndMessage(endGameMessageFromGameInfo(resp.data));
         }
       });
-    BoopSounds.playSound('startgameSound');
 
     return () => {
       clearChat();
@@ -257,6 +256,10 @@ export const Table = React.memo((props: Props) => {
       message.destroy();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameID]);
+
+  useEffect(() => {
+    BoopSounds.playSound('startgameSound');
   }, [gameID]);
 
   useEffect(() => {


### PR DESCRIPTION
this (along with #248) seems to reduce the instances where the sound doesn't play when starting a game vs the bot.

- not changing the logic (which is currently to play the sound _before_ the async call returns).
- not fixing the lack of `.catch` for axios