### PR TITLE
analyzer context

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { Button, Card } from 'antd';
 import { BulbOutlined } from '@ant-design/icons';
 import {
@@ -9,6 +15,7 @@ import { getMacondo } from '../wasm/loader';
 import { useMountedState } from '../utils/mounted';
 import { RedoOutlined } from '@ant-design/icons/lib';
 import { EmptySpace, EphemeralTile } from '../utils/cwgame/common';
+import { Unrace } from '../utils/unrace';
 
 type AnalyzerProps = {
   includeCard?: boolean;
@@ -101,11 +108,128 @@ export const analyzerMoveFromJsonMove = (
   };
 };
 
+const AnalyzerContext = React.createContext<{
+  cachedMoves: Array<AnalyzerMove> | null;
+  examinerLoading: boolean;
+  requestAnalysis: (lexicon: string) => void;
+  showMovesForTurn: number;
+  setShowMovesForTurn: (a: number) => void;
+}>({
+  cachedMoves: null,
+  examinerLoading: false,
+  requestAnalysis: (lexicon: string) => {},
+  showMovesForTurn: -1,
+  setShowMovesForTurn: (a: number) => {},
+});
+
+export const AnalyzerContextProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { useState } = useMountedState();
+
+  const [movesCache, setMovesCache] = useState<
+    Array<Array<AnalyzerMove> | null>
+  >([]);
+  const [showMovesForTurn, setShowMovesForTurn] = useState(-1);
+  const [unrace, setUnrace] = useState(new Unrace());
+
+  const {
+    gameContext: examinableGameContext,
+  } = useExaminableGameContextStoreContext();
+
+  const examinerId = useRef(0);
+  useEffect(() => {
+    examinerId.current = (examinerId.current + 1) | 0;
+    setMovesCache([]);
+    setUnrace(new Unrace());
+  }, [examinableGameContext.gameID]);
+
+  const requestAnalysis = useCallback(
+    (lexicon) => {
+      const examinerIdAtStart = examinerId.current;
+      const turn = examinableGameContext.turns.length;
+      // null = loading. undefined = not yet requested.
+      if (movesCache[turn] !== undefined) return;
+      setMovesCache((oldMovesCache) => {
+        const ret = [...oldMovesCache];
+        ret[turn] = null;
+        return ret;
+      });
+
+      unrace.run(async () => {
+        const {
+          board: { dim, letters },
+          onturn,
+          players,
+        } = examinableGameContext;
+
+        const boardObj = {
+          size: dim,
+          rack: players[onturn].currentRack,
+          board: Array.from(new Array(dim), (_, row) =>
+            letters.substr(row * dim, dim)
+          ),
+          lexicon,
+        };
+
+        const macondo = await getMacondo();
+        if (examinerIdAtStart !== examinerId.current) return;
+        await macondo.loadLexicon(lexicon);
+        if (examinerIdAtStart !== examinerId.current) return;
+
+        const boardStr = JSON.stringify(boardObj);
+        const movesStr = await macondo.analyze(boardStr);
+        if (examinerIdAtStart !== examinerId.current) return;
+        const movesObj = JSON.parse(movesStr) as Array<JsonMove>;
+
+        const formattedMoves = movesObj.map((move) =>
+          analyzerMoveFromJsonMove(move, dim, letters)
+        );
+        setMovesCache((oldMovesCache) => {
+          const ret = [...oldMovesCache];
+          ret[turn] = formattedMoves;
+          return ret;
+        });
+      });
+    },
+    [examinableGameContext, movesCache, unrace]
+  );
+
+  const cachedMoves = movesCache[examinableGameContext.turns.length];
+  const examinerLoading = cachedMoves === null;
+  const contextValue = useMemo(
+    () => ({
+      cachedMoves,
+      examinerLoading,
+      requestAnalysis,
+      showMovesForTurn,
+      setShowMovesForTurn,
+    }),
+    [
+      cachedMoves,
+      examinerLoading,
+      requestAnalysis,
+      showMovesForTurn,
+      setShowMovesForTurn,
+    ]
+  );
+
+  return <AnalyzerContext.Provider value={contextValue} children={children} />;
+};
+
 export const Analyzer = React.memo((props: AnalyzerProps) => {
   const { lexicon } = props;
   const { useState } = useMountedState();
-  const [moves, setMoves] = useState(new Array<AnalyzerMove>());
-  const [examinerLoading, setExaminerLoading] = useState(false);
+  const {
+    cachedMoves,
+    examinerLoading,
+    requestAnalysis,
+    showMovesForTurn,
+    setShowMovesForTurn,
+  } = useContext(AnalyzerContext);
+
   const {
     gameContext: examinableGameContext,
   } = useExaminableGameContextStoreContext();
@@ -114,13 +238,6 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     setPlacedTiles,
     setPlacedTilesTempScore,
   } = useTentativeTileContext();
-
-  const examinerId = useRef(0);
-
-  useEffect(() => {
-    setExaminerLoading(false);
-    examinerId.current = (examinerId.current + 1) | 0;
-  }, [moves]);
 
   const placeMove = useCallback(
     (move) => {
@@ -167,60 +284,34 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
       setPlacedTilesTempScore(move.score);
     },
     [
-      examinableGameContext,
+      examinableGameContext.board.dim,
+      examinableGameContext.board.letters,
       setDisplayedRack,
       setPlacedTiles,
       setPlacedTilesTempScore,
     ]
   );
 
-  const handleExaminer = React.useCallback(() => {
-    if (examinerLoading) {
-      return;
-    }
-    const examinerIdAtStart = examinerId.current;
-    (async () => {
-      const {
-        board: { dim, letters },
-        onturn,
-        players,
-      } = examinableGameContext;
-      setExaminerLoading(true);
-      const boardObj = {
-        size: dim,
-        rack: players[onturn].currentRack,
-        board: Array.from(new Array(dim), (_, row) =>
-          letters.substr(row * dim, dim)
-        ),
-        lexicon,
-      };
-
-      const macondo = await getMacondo();
-      if (examinerIdAtStart !== examinerId.current) return;
-      await macondo.loadLexicon(lexicon);
-      if (examinerIdAtStart !== examinerId.current) return;
-
-      const boardStr = JSON.stringify(boardObj);
-      const movesStr = await macondo.analyze(boardStr);
-      if (examinerIdAtStart !== examinerId.current) return;
-      const movesObj = JSON.parse(movesStr) as Array<JsonMove>;
-
-      const formattedMoves = movesObj.map((move) =>
-        analyzerMoveFromJsonMove(move, dim, letters)
-      );
-      setMoves(formattedMoves);
-    })();
-  }, [examinableGameContext, lexicon, examinerLoading]);
+  const handleExaminer = useCallback(() => {
+    setShowMovesForTurn(examinableGameContext.turns.length);
+    requestAnalysis(lexicon);
+  }, [examinableGameContext.turns.length, lexicon, requestAnalysis]);
 
   // When at the last move, examineStoreContext.examinedTurn === Infinity.
   // To also detect new moves, we use examinableGameContext.turns.length.
   useEffect(() => {
-    setMoves(new Array<AnalyzerMove>());
+    setShowMovesForTurn(-1);
   }, [examinableGameContext.turns.length]);
+
+  const showMoves = showMovesForTurn === examinableGameContext.turns.length;
+  const moves = useMemo(() => (showMoves ? cachedMoves : null), [
+    showMoves,
+    cachedMoves,
+  ]);
 
   const renderAnalyzerMoves = useMemo(
     () =>
-      moves.map((m: AnalyzerMove, idx) => (
+      moves?.map((m: AnalyzerMove, idx) => (
         <tr
           key={idx}
           onClick={() => {
@@ -233,7 +324,7 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
           <td className="move-leave">{m.leave}</td>
           <td className="move-equity">{m.equity}</td>
         </tr>
-      )),
+      )) ?? null,
     [moves, placeMove]
   );
 

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -1,4 +1,10 @@
-import React, { useRef, useCallback, useContext, useEffect } from 'react';
+import React, {
+  useRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+} from 'react';
 import { Button, Card } from 'antd';
 import { PlusOutlined } from '@ant-design/icons';
 import {
@@ -42,12 +48,12 @@ export const NotepadContextProvider = ({
 }) => {
   const { useState } = useMountedState();
   const [curNotepad, setCurNotepad] = useState('');
-  return (
-    <NotepadContext.Provider
-      value={{ curNotepad, setCurNotepad }}
-      children={children}
-    />
-  );
+  const contextValue = useMemo(() => ({ curNotepad, setCurNotepad }), [
+    curNotepad,
+    setCurNotepad,
+  ]);
+
+  return <NotepadContext.Provider value={contextValue} children={children} />;
 };
 
 export const Notepad = React.memo((props: NotepadProps) => {

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -48,7 +48,7 @@ import { PlayState } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import { endGameMessageFromGameInfo } from '../store/end_of_game';
 import { singularCount } from '../utils/plural';
 import { Notepad, NotepadContextProvider } from './notepad';
-import { Analyzer } from './analyzer';
+import { Analyzer, AnalyzerContextProvider } from './analyzer';
 
 type Props = {
   sendSocketMsg: (msg: Uint8Array) => void;
@@ -550,5 +550,6 @@ export const Table = React.memo((props: Props) => {
     </div>
   );
   ret = <NotepadContextProvider children={ret} />;
+  ret = <AnalyzerContextProvider children={ret} />;
   return ret;
 });


### PR DESCRIPTION
- share context across views to avoid losing analysis when switching to/from tablet view.
- remember analyzed moves by turn in a sparse array. `null` = loading/analyzing. `undefined` = not yet requested.
- when returning to a previously analyzed move, cached analysis is returned immediately.