### PR TITLE
do not send chat message if not logged in

### DIFF
--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -163,13 +163,16 @@ export const Chat = React.memo((props: Props) => {
         if (msg === '') {
           return;
         }
+        if (!loggedIn) {
+          return;
+        }
         propsSendChat(msg);
         // This may not be a good idea. User will miss unread messages.
         setChatAutoScroll(true);
         doChatAutoScroll();
       }
     },
-    [curMsg, doChatAutoScroll, propsSendChat]
+    [curMsg, doChatAutoScroll, loggedIn, propsSendChat]
   );
 
   return (


### PR DESCRIPTION
previously it was possible to use inspector, remove the disabled attribute, and send chat message anonymously after all