### PR TITLE
fix null premove

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -426,10 +426,14 @@ export const BoardPanel = React.memo((props: Props) => {
         hookChanged(row, col, +1, 0) ||
         hookChanged(row, col, 0, -1) ||
         hookChanged(row, col, 0, +1);
+      // If no tiles have been placed, but placement arrow is shown,
+      // reset based on if that position is affected.
+      // This avoids having the placement arrow behind a tile.
       if (
-        Array.from(dep.placedTiles).some(({ row, col }) =>
-          placedTileAffected(row, col)
-        )
+        (dep.placedTiles.size === 0 && arrowProperties.show
+          ? [arrowProperties as { row: number; col: number }]
+          : Array.from(dep.placedTiles)
+        ).some(({ row, col }) => placedTileAffected(row, col))
       ) {
         fullReset = true;
       }
@@ -442,6 +446,7 @@ export const BoardPanel = React.memo((props: Props) => {
     }
     lastLettersRef.current = props.board.letters;
   }, [
+    arrowProperties,
     isExamining,
     props.board.letters,
     props.currentRack,


### PR DESCRIPTION
#308 highlights a case not covered by #80. The player placed the placement arrow at 8D, the opponent placed 8D KERBS which affected that square, and because there was no tile placed yet the premove was not reset. The player then placed one tile (E) under the K placed by the opponent, and the score was evaluated as EERBS = 8 pts.

This fix handles the case when there's a placement arrow but no placed tile as if there's a placed tile where the placement arrow is, so it would reset accordingly.

(This issue is not related to #303.)

Also improving code clarity by having less ref-based dependencies.