### PR TITLE
customizable tile order

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -16,6 +16,7 @@ import { useMountedState } from '../utils/mounted';
 import { RedoOutlined } from '@ant-design/icons/lib';
 import { EmptySpace, EphemeralTile } from '../utils/cwgame/common';
 import { Unrace } from '../utils/unrace';
+import { sortTiles } from '../store/constants';
 
 type AnalyzerProps = {
   includeCard?: boolean;
@@ -54,6 +55,7 @@ export const analyzerMoveFromJsonMove = (
   dim: number,
   letters: string
 ): AnalyzerMove => {
+  let tilesBeingMoved = move.Tiles;
   let displayMove = '';
   let isExchange = false;
   switch (move.Action) {
@@ -82,7 +84,8 @@ export const analyzerMoveFromJsonMove = (
       break;
     }
     case 'Exchange': {
-      displayMove = `Exch. ${move.Tiles}`;
+      tilesBeingMoved = sortTiles(tilesBeingMoved);
+      displayMove = `Exch. ${tilesBeingMoved}`;
       isExchange = true;
       break;
     }
@@ -97,13 +100,13 @@ export const analyzerMoveFromJsonMove = (
   return {
     displayMove,
     coordinates: move.DisplayCoordinates,
-    leave: move.Leave,
+    leave: sortTiles(move.Leave),
     vertical: move.Vertical,
     col: move.Column,
     row: move.Row,
     score: move.Score,
     equity: move.Equity.toFixed(2),
-    tiles: move.Tiles,
+    tiles: tilesBeingMoved,
     isExchange,
   };
 };

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -11,7 +11,7 @@ import {
   useGameContextStoreContext,
   useTentativeTileContext,
 } from '../store/store';
-import { sortBlanksLast } from '../store/constants';
+import { sortTiles } from '../store/constants';
 import {
   contiguousTilesFromTileSet,
   simpletile,
@@ -70,7 +70,7 @@ export const Notepad = React.memo((props: NotepadProps) => {
     const contiguousTiles = contiguousTilesFromTileSet(placedTiles, board);
     let play = '';
     let position = '';
-    const leave = sortBlanksLast(displayedRack.split('').sort().join(''));
+    const leave = sortTiles(displayedRack.split('').sort().join(''));
     if (contiguousTiles?.length === 2) {
       position = humanReadablePosition(
         contiguousTiles[1],

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -16,7 +16,7 @@ import { PlayerMetadata } from './game_info';
 import { Turn, gameEventsToTurns } from '../store/reducers/turns';
 import { PoolFormatType } from '../constants/pool_formats';
 import { Notepad } from './notepad';
-import { sortBlanksLast } from '../store/constants';
+import { sortTiles } from '../store/constants';
 import { getVW, isTablet } from '../utils/cwgame/common';
 import { Analyzer } from './analyzer';
 const screenSizes = require('../base.scss');
@@ -61,7 +61,7 @@ const displaySummary = (evt: GameEvent, board: Board) => {
   switch (evt.getType()) {
     case GameEvent.Type.EXCHANGE:
       return (
-        <span className="exchanged">-{sortBlanksLast(evt.getExchanged())}</span>
+        <span className="exchanged">-{sortTiles(evt.getExchanged())}</span>
       );
 
     case GameEvent.Type.PASS:
@@ -135,7 +135,7 @@ const ScorecardTurn = (props: turnProps) => {
       oldScore: oldScore,
     };
     if (evts.length === 1) {
-      turn.rack = sortBlanksLast(turn.rack);
+      turn.rack = sortTiles(turn.rack);
       return turn;
     }
     // Otherwise, we have to make some modifications.
@@ -162,7 +162,7 @@ const ScorecardTurn = (props: turnProps) => {
             </span>
           </>
         );
-        turn.rack = `Play is valid ${sortBlanksLast(evts[0].getRack())}`;
+        turn.rack = `Play is valid ${sortTiles(evts[0].getRack())}`;
       }
       // Otherwise, just add/subtract as needed.
       for (let i = 1; i < evts.length; i++) {

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -47,6 +47,7 @@ import { singularCount } from '../utils/plural';
 import { Notepad, NotepadContextProvider } from './notepad';
 import { Analyzer, AnalyzerContextProvider } from './analyzer';
 import { TournamentMetadata } from '../tournament/state';
+import { sortTiles } from '../store/constants';
 
 type Props = {
   sendSocketMsg: (msg: Uint8Array) => void;
@@ -407,19 +408,21 @@ export const Table = React.memo((props: Props) => {
   // If we are one of the players, display our rack.
   // If we are NOT one of the players (so an observer), display the rack of
   // the player on turn.
-  let rack;
+  let rack: string;
   const gameDone = gameContext.playState === PlayState.GAME_OVER;
   const us = useMemo(() => gameInfo.players.find((p) => p.user_id === userID), [
     gameInfo.players,
     userID,
   ]);
   if (us && !(gameDone && isExamining)) {
-    rack = examinableGameContext.players.find((p) => p.userID === us.user_id)
-      ?.currentRack;
+    rack =
+      examinableGameContext.players.find((p) => p.userID === us.user_id)
+        ?.currentRack ?? '';
   } else {
     rack =
-      examinableGameContext.players.find((p) => p.onturn)?.currentRack || '';
+      examinableGameContext.players.find((p) => p.onturn)?.currentRack ?? '';
   }
+  const sortedRack = useMemo(() => sortTiles(rack), [rack]);
 
   // The game "starts" when the GameHistoryRefresher object comes in via the socket.
   // At that point gameID will be filled in.
@@ -548,7 +551,7 @@ export const Table = React.memo((props: Props) => {
           <BoardPanel
             username={username}
             board={examinableGameContext.board}
-            currentRack={rack || ''}
+            currentRack={sortedRack}
             events={examinableGameContext.turns}
             gameID={gameID}
             sendSocketMsg={props.sendSocketMsg}
@@ -575,7 +578,7 @@ export const Table = React.memo((props: Props) => {
           />
           <Pool
             pool={examinableGameContext?.pool}
-            currentRack={rack || ''}
+            currentRack={sortedRack}
             poolFormat={poolFormat}
             setPoolFormat={setPoolFormat}
           />

--- a/liwords-ui/src/store/constants.ts
+++ b/liwords-ui/src/store/constants.ts
@@ -132,15 +132,27 @@ export const challRuleToStr = (n: number): string => {
   return 'Unsupported';
 };
 
-export const sortBlanksLast = (rack: string) => {
-  let letters = '';
-  let blanks = '';
-  for (const tile of rack) {
-    if (tile === Blank) {
-      blanks += tile;
-    } else {
-      letters += tile;
-    }
-  }
-  return letters + blanks;
+// To expose this and make it more ergonomic to reorder without refreshing.
+const preferredSortOrder = localStorage.getItem('tileOrder');
+
+export const sortTiles = (rack: string) => {
+  let effectiveSortOrder = preferredSortOrder ?? '';
+  return Array.from(rack, (tile) => {
+    let index = effectiveSortOrder.indexOf(tile);
+    if (index < 0) index = effectiveSortOrder.length + (tile === Blank ? 1 : 0);
+    return [index, tile];
+  })
+    .sort(([aIndex, aTile], [bIndex, bTile]) =>
+      aIndex < bIndex
+        ? -1
+        : aIndex > bIndex
+        ? 1
+        : aTile < bTile
+        ? -1
+        : aTile > bTile
+        ? 1
+        : 0
+    )
+    .map(([index, tile]) => tile)
+    .join('');
 };

--- a/liwords-ui/src/store/constants.ts
+++ b/liwords-ui/src/store/constants.ts
@@ -153,6 +153,5 @@ export const sortTiles = (rack: string) => {
         ? 1
         : 0
     )
-    .map(([index, tile]) => tile)
-    .join('');
+    .reduce((s, [index, tile]) => s + tile, '');
 };


### PR DESCRIPTION
usage:
- set `tileOrder`, then refresh
- unspecified tiles will be sorted after specified tiles, in codepoint order, blanks last

examples:

```js
localStorage.setItem('tileOrder', 'AEIOU'); // vowels first
localStorage.setItem('tileOrder', 'BCDFGHJKLMNPQRSTVWXYZ'); // consonants first
localStorage.setItem('tileOrder', 'QZJXKFHVWYBCMPDG'); // descending points
localStorage.setItem('tileOrder', '?'); // blanks first
localStorage.removeItem('tileOrder'); // default (blanks last)
```
