### PR TITLE
confirm pass/challenge shortcut

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -189,6 +189,22 @@ export const BoardPanel = React.memo((props: Props) => {
   const { gameContext } = useGameContextStoreContext();
   const { stopClock } = useTimerStoreContext();
   const [exchangeAllowed, setexchangeAllowed] = useState(true);
+  const handlePassShortcut = useRef<(() => void) | null>(null);
+  const setHandlePassShortcut = useCallback((x) => {
+    handlePassShortcut.current =
+      typeof x === 'function' ? x(handlePassShortcut.current) : x;
+  }, []);
+  const handleChallengeShortcut = useRef<(() => void) | null>(null);
+  const setHandleChallengeShortcut = useCallback((x) => {
+    handleChallengeShortcut.current =
+      typeof x === 'function' ? x(handleChallengeShortcut.current) : x;
+  }, []);
+  const handleNeitherShortcut = useRef<(() => void) | null>(null);
+  const setHandleNeitherShortcut = useCallback((x) => {
+    handleNeitherShortcut.current =
+      typeof x === 'function' ? x(handleNeitherShortcut.current) : x;
+  }, []);
+  const boardContainer = useRef<HTMLDivElement>(null);
 
   const {
     displayedRack,
@@ -270,6 +286,10 @@ export const BoardPanel = React.memo((props: Props) => {
       // Don't stop the clock; the next user event to come in will change the
       // clock over.
       // stopClock();
+      if (boardContainer.current) {
+        // Reenable keyboard shortcut after passing with 22.
+        boardContainer.current.focus();
+      }
     },
     [
       gameContext.nickToPlayerOrder,
@@ -581,16 +601,18 @@ export const BoardPanel = React.memo((props: Props) => {
         if (isMyTurn() && !props.gameDone) {
           if (key === '2') {
             evt.preventDefault();
-            makeMove('pass');
+            if (handlePassShortcut.current) handlePassShortcut.current();
             return;
           }
           if (key === '3') {
             evt.preventDefault();
-            makeMove('challenge');
+            if (handleChallengeShortcut.current)
+              handleChallengeShortcut.current();
             return;
           }
           if (key === '4' && exchangeAllowed) {
             evt.preventDefault();
+            if (handleNeitherShortcut.current) handleNeitherShortcut.current();
             setCurrentMode('EXCHANGE_MODAL');
             return;
           }
@@ -960,6 +982,7 @@ export const BoardPanel = React.memo((props: Props) => {
   const gameBoard = (
     <div
       id="board-container"
+      ref={boardContainer}
       className="board-container"
       onKeyDown={handleKeyDown}
       onKeyPress={preventFirefoxTypeToSearch}
@@ -1045,6 +1068,9 @@ export const BoardPanel = React.memo((props: Props) => {
         tournamentSlug={props.tournamentSlug}
         lexicon={props.lexicon}
         challengeRule={props.challengeRule}
+        setHandlePassShortcut={setHandlePassShortcut}
+        setHandleChallengeShortcut={setHandleChallengeShortcut}
+        setHandleNeitherShortcut={setHandleNeitherShortcut}
       />
       <ExchangeTiles
         rack={props.currentRack}

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { Button, Popconfirm } from 'antd';
 import {
@@ -89,26 +89,114 @@ export type Props = {
   tournamentSlug?: string;
   lexicon: string;
   challengeRule: ChallengeRule;
+  setHandlePassShortcut: ((handler: (() => void) | null) => void) | null;
+  setHandleChallengeShortcut: ((handler: (() => void) | null) => void) | null;
+  setHandleNeitherShortcut: ((handler: (() => void) | null) => void) | null;
 };
 
 const GameControls = React.memo((props: Props) => {
   const { useState } = useMountedState();
-  const [passVisible, setPassVisible] = useState(false);
-  const [challengeVisible, setChallengeVisible] = useState(false);
-  const [resignVisible, setResignVisible] = useState(false);
+
+  // Poka-yoke against accidentally having multiple pop-ups active.
+  const [actualCurrentPopUp, setCurrentPopUp] = useState<
+    'NONE' | 'CHALLENGE' | 'PASS' | 'RESIGN'
+  >('NONE');
+  // This should match disabled= and/or hidden= props.
+  const currentPopUp =
+    (actualCurrentPopUp === 'CHALLENGE' &&
+      (!props.myTurn || props.challengeRule === 'VOID')) ||
+    (actualCurrentPopUp === 'PASS' && !props.myTurn)
+      ? 'NONE'
+      : actualCurrentPopUp;
+  useEffect(() => {
+    if (currentPopUp !== actualCurrentPopUp) {
+      // Although this will still take another render, make this render correct
+      // to avoid temporarily showing confirmation dialog.
+      setCurrentPopUp(currentPopUp);
+    }
+  }, [currentPopUp, actualCurrentPopUp]);
+
+  const passButton = useRef<HTMLElement>(null);
+  const challengeButton = useRef<HTMLElement>(null);
 
   const history = useHistory();
-  const handleExitToLobby = React.useCallback(() => {
+  const handleExitToLobby = useCallback(() => {
     props.tournamentSlug
       ? history.replace(props.tournamentSlug)
       : history.replace('/');
   }, [history, props.tournamentSlug]);
 
-  if (props.isExamining) {
+  const {
+    isExamining,
+    gameEndControls,
+    observer,
+    onChallenge,
+    onPass,
+    setHandlePassShortcut,
+    setHandleChallengeShortcut,
+    setHandleNeitherShortcut,
+  } = props;
+  const hasRegularButtons = !(isExamining || gameEndControls || observer);
+  const handlePassShortcut = useCallback(() => {
+    if (!hasRegularButtons) return;
+    if (!passButton.current) return;
+    passButton.current.focus();
+    setCurrentPopUp((v) => {
+      if (v !== 'PASS') return 'PASS';
+      if (onPass) onPass();
+      return 'NONE';
+    });
+  }, [hasRegularButtons, onPass]);
+  const handleChallengeShortcut = useCallback(() => {
+    if (!hasRegularButtons) return;
+    if (!challengeButton.current) return;
+    challengeButton.current.focus();
+    setCurrentPopUp((v) => {
+      if (v !== 'CHALLENGE') return 'CHALLENGE';
+      if (onChallenge) onChallenge();
+      return 'NONE';
+    });
+  }, [hasRegularButtons, onChallenge]);
+  const handleNeitherShortcut = useCallback(() => {
+    if (!hasRegularButtons) return;
+    setCurrentPopUp('NONE');
+  }, [hasRegularButtons]);
+  useEffect(() => {
+    if (!setHandlePassShortcut) return;
+    return () => {
+      setHandlePassShortcut(null);
+    };
+  }, [setHandlePassShortcut]);
+  useEffect(() => {
+    if (!setHandleChallengeShortcut) return;
+    return () => {
+      setHandleChallengeShortcut(null);
+    };
+  }, [setHandleChallengeShortcut]);
+  useEffect(() => {
+    if (!setHandleNeitherShortcut) return;
+    return () => {
+      setHandleNeitherShortcut(null);
+    };
+  }, [setHandleNeitherShortcut]);
+  useEffect(() => {
+    if (!setHandlePassShortcut) return;
+    setHandlePassShortcut(() => handlePassShortcut);
+  }, [handlePassShortcut, setHandlePassShortcut]);
+  useEffect(() => {
+    if (!setHandleChallengeShortcut) return;
+    setHandleChallengeShortcut(() => handleChallengeShortcut);
+  }, [handleChallengeShortcut, setHandleChallengeShortcut]);
+  useEffect(() => {
+    if (!setHandleNeitherShortcut) return;
+    setHandleNeitherShortcut(() => handleNeitherShortcut);
+  }, [handleNeitherShortcut, setHandleNeitherShortcut]);
+
+  if (isExamining) {
     return <ExamineGameControls lexicon={props.lexicon} />;
   }
 
-  if (props.gameEndControls) {
+  if (gameEndControls) {
     return (
       <EndGameControls
         onRematch={props.onRematch}
@@ -120,7 +208,7 @@ const GameControls = React.memo((props: Props) => {
     );
   }
 
-  if (props.observer) {
+  if (observer) {
     return (
       <div className="game-controls">
         <Button onClick={props.onExamine}>Examine</Button>
@@ -129,35 +217,30 @@ const GameControls = React.memo((props: Props) => {
     );
   }
 
-  // Temporary dead code.
-  if (props.observer) {
-    return null;
-  }
-
   return (
     <div className="game-controls">
       <div className="secondary-controls">
         <Popconfirm
           title="Are you sure you wish to resign?"
           onCancel={() => {
-            setResignVisible(false);
+            setCurrentPopUp('NONE');
           }}
           onConfirm={() => {
             props.onResign();
-            setResignVisible(false);
+            setCurrentPopUp('NONE');
           }}
           onVisibleChange={(visible) => {
-            setResignVisible(visible);
+            setCurrentPopUp(visible ? 'RESIGN' : 'NONE');
           }}
           okText="Yes"
           cancelText="No"
-          visible={resignVisible}
+          visible={currentPopUp === 'RESIGN'}
         >
           <Button
             danger
             onDoubleClick={() => {
               props.onResign();
-              setResignVisible(false);
+              setCurrentPopUp('NONE');
             }}
           >
             Resign
@@ -167,23 +250,24 @@ const GameControls = React.memo((props: Props) => {
         <Popconfirm
           title="Are you sure you wish to pass?"
           onCancel={() => {
-            setPassVisible(false);
+            setCurrentPopUp('NONE');
           }}
           onConfirm={() => {
             props.onPass();
-            setPassVisible(false);
+            setCurrentPopUp('NONE');
           }}
           onVisibleChange={(visible) => {
-            setPassVisible(visible);
+            setCurrentPopUp(visible ? 'PASS' : 'NONE');
           }}
           okText="Yes"
           cancelText="No"
-          visible={passVisible}
+          visible={currentPopUp === 'PASS'}
         >
           <Button
+            ref={passButton}
             onDoubleClick={() => {
               props.onPass();
-              setPassVisible(false);
+              setCurrentPopUp('NONE');
             }}
             danger
             disabled={!props.myTurn}
@@ -200,23 +284,24 @@ const GameControls = React.memo((props: Props) => {
         <Popconfirm
           title="Are you sure you wish to challenge?"
           onCancel={() => {
-            setChallengeVisible(false);
+            setCurrentPopUp('NONE');
           }}
           onConfirm={() => {
             props.onChallenge();
-            setChallengeVisible(false);
+            setCurrentPopUp('NONE');
           }}
           onVisibleChange={(visible) => {
-            setChallengeVisible(visible);
+            setCurrentPopUp(visible ? 'CHALLENGE' : 'NONE');
           }}
           okText="Yes"
           cancelText="No"
-          visible={challengeVisible}
+          visible={currentPopUp === 'CHALLENGE'}
         >
           <Button
+            ref={challengeButton}
             onDoubleClick={() => {
               props.onChallenge();
-              setChallengeVisible(false);
+              setCurrentPopUp('NONE');
             }}
             disabled={!props.myTurn}
             hidden={props.challengeRule === 'VOID'}


### PR DESCRIPTION
this changes the pass/challenge shortcut to 22 and 33 respectively. (there is no time limit to double-press. pressing 2 when the confirmation pop-up isn't shown shows it, and pressing it when it's shown (even if it's by mouse) effects the pass.)

most of the code is to workaround antd (and/or typescript), and fixes current issues like
- if you click Resign/Pass/Challenge and then press 4, the exchange modal was shown while the Resign/Pass/Challenge confirmation was still showing
- if you pass/challenge with the mouse (i.e. not with 2 or 3) the board wasn't focused anymore and you cannot pass/challenge the next turn with 2/3. this applied whether you double-click the button or you click Yes on the confirmation
- it was possible to challenge in void by pressing 3 (backend will still return error message) despite the button being hidden

the handler settlers, if provided, will be called on mount/change and called with null on unmount, so it's like how callback refs work.