### PR TITLE
reorder css to avoid hover styling on disabled exchange button

### DIFF
--- a/liwords-ui/src/base.scss
+++ b/liwords-ui/src/base.scss
@@ -573,12 +573,6 @@ ul
     &:not(.ant-btn-circle) {
       padding: 3px 18px;
     }
-    &:disabled {
-      @include colorModed() {
-        border-color: m($gray-subtle);
-        color: m($gray-subtle);
-      }
-    }
 
     span.key-command {
       position: absolute;
@@ -598,6 +592,12 @@ ul
         background-color: m($background);
         border-color: m($primary-dark);
         color:  m($primary-dark);
+      }
+    }
+    &:disabled {
+      @include colorModed() {
+        border-color: m($gray-subtle);
+        color: m($gray-subtle);
       }
     }
     &:not([disabled]):hover {


### PR DESCRIPTION
currently when exchange button is disabled (because it's opponent's turn) hovering over it shows hover styling

<img width="491" alt="Screenshot 2021-01-05 at 15 38 00" src="https://user-images.githubusercontent.com/4179698/103619137-258d1f80-4f6c-11eb-95e2-e8f8e7e64b49.png">