### PR TITLE
profile settings for tile order

### DIFF
--- a/liwords-ui/src/profile/profile.tsx
+++ b/liwords-ui/src/profile/profile.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect } from 'react';
 import { Link, useParams, useLocation } from 'react-router-dom';
-import { notification, Card, Table, Row, Col, Switch } from 'antd';
+import { notification, Card, Table, Row, Col, Select, Switch } from 'antd';
 import axios, { AxiosError } from 'axios';
 import { useMountedState } from '../utils/mounted';
 import { TopBar } from '../topbar/topbar';
@@ -11,6 +11,7 @@ import { useLoginStateStoreContext } from '../store/store';
 import { GameMetadata, RecentGamesResponse } from '../gameroom/game_info';
 import { GamesHistoryCard } from './games_history';
 import { UsernameWithContext } from '../shared/usernameWithContext';
+import { preferredSortOrder, setPreferredSortOrder } from '../store/constants';
 
 type ProfileResponse = {
   first_name: string;
@@ -200,6 +201,29 @@ type Props = {};
 
 const gamesPageSize = 10;
 
+const KNOWN_TILE_ORDERS = [
+  {
+    name: 'Alphabetical',
+    value: '',
+  },
+  {
+    name: 'Vowels first',
+    value: 'AEIOU',
+  },
+  {
+    name: 'Consonants first',
+    value: 'BCDFGHJKLMNPQRSTVWXYZ',
+  },
+  {
+    name: 'Descending points',
+    value: 'QZJXKFHVWYBCMPDG',
+  },
+  {
+    name: 'Blanks first',
+    value: '?',
+  },
+];
+
 export const UserProfile = React.memo((props: Props) => {
   const { useState } = useMountedState();
 
@@ -212,6 +236,11 @@ export const UserProfile = React.memo((props: Props) => {
   const [darkMode, setDarkMode] = useState(
     localStorage?.getItem('darkMode') === 'true'
   );
+  const [tileOrder, setTileOrder] = useState(preferredSortOrder ?? '');
+  const handleTileOrderChange = useCallback((value) => {
+    setTileOrder(value);
+    setPreferredSortOrder(value);
+  }, []);
   const [recentGames, setRecentGames] = useState<Array<GameMetadata>>([]);
   const { loginState } = useLoginStateStoreContext();
   const { username: viewer } = loginState;
@@ -302,6 +331,22 @@ export const UserProfile = React.memo((props: Props) => {
           </h3>
           {viewer === username ? (
             <div>
+              <label>
+                Tile order{' '}
+                <Select
+                  defaultValue={tileOrder}
+                  onChange={handleTileOrderChange}
+                >
+                  {KNOWN_TILE_ORDERS.map(({ name, value }) => (
+                    <Select.Option value={value} key={value}>
+                      {name}
+                    </Select.Option>
+                  ))}
+                  {KNOWN_TILE_ORDERS.some(
+                    ({ value }) => value === tileOrder
+                  ) || <Select.Option value={tileOrder}>Custom</Select.Option>}
+                </Select>
+              </label>{' '}
               <label>Enable dark mode</label>
               <Switch
                 defaultChecked={darkMode}

--- a/liwords-ui/src/store/constants.ts
+++ b/liwords-ui/src/store/constants.ts
@@ -133,7 +133,17 @@ export const challRuleToStr = (n: number): string => {
 };
 
 // To expose this and make it more ergonomic to reorder without refreshing.
-const preferredSortOrder = localStorage.getItem('tileOrder');
+export let preferredSortOrder = localStorage.getItem('tileOrder');
+
+export const setPreferredSortOrder = (value: string) => {
+  if (value) {
+    localStorage.setItem('tileOrder', value);
+    preferredSortOrder = value;
+  } else {
+    localStorage.removeItem('tileOrder');
+    preferredSortOrder = null;
+  }
+};
 
 export const sortTiles = (rack: string) => {
   let effectiveSortOrder = preferredSortOrder ?? '';


### PR DESCRIPTION
localStorage, same as darkMode
see #340 

<img width="560" alt="Screenshot 2021-01-06 at 13 09 37" src="https://user-images.githubusercontent.com/4179698/103731739-d81eba00-5020-11eb-9811-a5b55feba026.png">
