### PR TITLE
fix scorecard avatars when secondWentFirst is false

### DIFF
--- a/liwords-ui/src/shared/player_avatar.tsx
+++ b/liwords-ui/src/shared/player_avatar.tsx
@@ -23,9 +23,10 @@ export const PlayerAvatar = (props: AvatarProps) => {
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>('');
   const [avatarFile, setAvatarFile] = useState(new File([''], ''));
 
+  const avatarUrlFromProps = props.player?.avatar_url;
   useEffect(() => {
-    setAvatarUrl(props.player?.avatar_url);
-  }, [props.player]);
+    setAvatarUrl(avatarUrlFromProps);
+  }, [avatarUrlFromProps]);
 
   useEffect(() => {
     setAvatarErr('');


### PR DESCRIPTION
i have no idea why #417 wasn't working iff secondWentFirst is false, why this patch (which doesn't actually fix anything) seems to work around whatever was wrong, and what this breaks in exchange...