### PR TITLE
Clean up avatar-fetching

### DIFF
--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -307,14 +307,17 @@ export const Table = React.memo((props: Props) => {
       )
       .then((resp) => {
         setNeedAvatars(false);
-        let players = JSON.parse(JSON.stringify(gameInfo.players));
+        let players = [...gameInfo.players];
         resp.data.infos.forEach((info) => {
           if (info.avatar_url.length) {
             const index = gameInfo.players.findIndex(
               (p) => p.user_id === info.uuid
             );
             if (index >= 0) {
-              players[index].avatar_url = info.avatar_url;
+              players[index] = {
+                ...players[index],
+                avatar_url: info.avatar_url,
+              };
             }
           }
         });

--- a/liwords-ui/src/profile/profile.tsx
+++ b/liwords-ui/src/profile/profile.tsx
@@ -371,6 +371,7 @@ export const UserProfile = React.memo((props: Props) => {
             <PlayerAvatar
               player={player}
               editable={avatarEditable}
+              username={username}
             ></PlayerAvatar>
           </h3>
           {viewer === username ? (

--- a/liwords-ui/src/shared/player_avatar.tsx
+++ b/liwords-ui/src/shared/player_avatar.tsx
@@ -11,6 +11,7 @@ const colors = require('../base.scss');
 
 type AvatarProps = {
   player: Partial<PlayerMetadata> | undefined;
+  username?: string;
   withTooltip?: boolean;
   editable?: boolean;
 };
@@ -65,7 +66,6 @@ export const PlayerAvatar = (props: AvatarProps) => {
         setUpdateModalVisible(false);
       }}
       onOk={() => {
-        console.log(avatarFile);
         let reader = new FileReader();
         reader.onload = () => {
           axios
@@ -136,7 +136,10 @@ export const PlayerAvatar = (props: AvatarProps) => {
       <div className="player-avatar" style={avatarStyle}>
         {!avatarUrl
           ? fixedCharAt(
-              props.player?.full_name || props.player?.nickname || '?',
+              props.player?.full_name ||
+                props.player?.nickname ||
+                props.username ||
+                '?',
               0,
               1
             )

--- a/liwords-ui/src/shared/player_avatar.tsx
+++ b/liwords-ui/src/shared/player_avatar.tsx
@@ -23,14 +23,13 @@ export const PlayerAvatar = (props: AvatarProps) => {
   const [avatarUrl, setAvatarUrl] = useState<string | undefined>('');
   const [avatarFile, setAvatarFile] = useState(new File([''], ''));
 
-  const avatarUrlFromProps = props.player?.avatar_url;
   useEffect(() => {
-    setAvatarUrl(avatarUrlFromProps);
-  }, [avatarUrlFromProps]);
+    setAvatarUrl(props.player?.avatar_url);
+  }, [props.player]);
 
   useEffect(() => {
     setAvatarErr('');
-    var fileInput = document.getElementById(
+    let fileInput = document.getElementById(
       'avatar-file-input'
     ) as HTMLInputElement;
     if (fileInput !== null) {
@@ -38,7 +37,7 @@ export const PlayerAvatar = (props: AvatarProps) => {
     }
   }, [updateModalVisible]);
 
-  var okButtonDisabled = avatarFile == null || avatarFile.name.length === 0;
+  let okButtonDisabled = avatarFile == null || avatarFile.name.length === 0;
   const fileProps = {
     beforeUpload: (file: File) => {
       return false;
@@ -67,8 +66,8 @@ export const PlayerAvatar = (props: AvatarProps) => {
       }}
       onOk={() => {
         console.log(avatarFile);
-        var reader = new FileReader();
-        reader.onload = function () {
+        let reader = new FileReader();
+        reader.onload = () => {
           axios
             .post(
               toAPIUrl('user_service.ProfileService', 'UpdateAvatar'),
@@ -86,7 +85,6 @@ export const PlayerAvatar = (props: AvatarProps) => {
               });
               setUpdateModalVisible(false);
               setAvatarUrl(resp.data.avatar_url);
-              console.log(resp.data.avatar_url);
             })
             .catch((e) => {
               if (e.response) {


### PR DESCRIPTION
* Updates gameInfo properly when avatars are found. 
* Removes now-unnecessary change to player_avatar.tsx. 
* Uses arrow functions and let/const vs. var in places.

In the previous table.tsx, the call to setGameInfo( ) didn't actually trigger a rerender, as the shallow copying updated gameInfo under the hood *before* setGameInfo( ) was called.
To fix this, I now deep-copy the players field out of gameInfo, update it, and then call setGameInfo( ).

The result of this is an infinite loop of rendering, as the avatar-fetching effect hook both depends on—and changes—gameInfo. The "needsAvatar" breaks the chain; it's set when the game info is initially loaded, and cleared once the avatars are fetched.

The "voodoo" code in player_avatar.tsx that somehow fixed the no-avatar issue has been removed. 

Alternative solutions are welcome! 