### PR TITLE
fix truncated board coordinates

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -487,7 +487,6 @@ p.streak-loss {
   font-weight: 400;
   font-family: $font-monospaced;
   letter-spacing: -0.05em;
-  overflow: hidden;
   @include colorModed() {
     color: m($gray-extreme);
   }


### PR DESCRIPTION
currently the right side of letters like ADGHKMNO are cut off. (mobile view)

<img width="497" alt="Screenshot 2021-02-20 at 16 03 14" src="https://user-images.githubusercontent.com/4179698/108588769-dbce8c00-7395-11eb-9ea0-28dfd21bcbe2.png">

this fixes them to

<img width="501" alt="Screenshot 2021-02-20 at 16 04 11" src="https://user-images.githubusercontent.com/4179698/108588784-f86ac400-7395-11eb-9ecb-307f9b93371b.png">