### PR TITLE
adjust time low cutoff

### DIFF
--- a/liwords-ui/src/gameroom/player_cards.tsx
+++ b/liwords-ui/src/gameroom/player_cards.tsx
@@ -49,7 +49,7 @@ const PlayerCard = React.memo((props: CardProps) => {
   const timeStr =
     isExamining || props.playing ? millisToTimeStr(props.time) : '--:--';
   // TODO: what we consider low time likely be set somewhere and not a magic number
-  const timeLowCutoff = props.initialTimeSeconds / 5;
+  const timeLowCutoff = Math.max(props.initialTimeSeconds / 5, 30000);
   const timeLow = props.time <= timeLowCutoff && props.time > 0;
   const timeOut = props.time <= 0;
   return (

--- a/liwords-ui/src/gameroom/player_cards.tsx
+++ b/liwords-ui/src/gameroom/player_cards.tsx
@@ -18,6 +18,7 @@ const colors = require('../base.scss');
 type CardProps = {
   player: RawPlayerInfo | undefined;
   time: Millis;
+  initialTimeSeconds: Millis;
   meta: Array<PlayerMetadata>;
   playing: boolean;
   score: number;
@@ -48,7 +49,8 @@ const PlayerCard = React.memo((props: CardProps) => {
   const timeStr =
     isExamining || props.playing ? millisToTimeStr(props.time) : '--:--';
   // TODO: what we consider low time likely be set somewhere and not a magic number
-  const timeLow = props.time <= 180000 && props.time > 0;
+  const timeLowCutoff = props.initialTimeSeconds / 5;
+  const timeLow = props.time <= timeLowCutoff && props.time > 0;
   const timeOut = props.time <= 0;
   return (
     <div
@@ -165,6 +167,7 @@ export const PlayerCards = React.memo((props: Props) => {
         player={p0}
         meta={props.playerMeta}
         time={p0Time}
+        initialTimeSeconds={initialTimeSeconds}
         score={p0Score}
         spread={p0Spread}
         playing={playing}
@@ -173,6 +176,7 @@ export const PlayerCards = React.memo((props: Props) => {
         player={p1}
         meta={props.playerMeta}
         time={p1Time}
+        initialTimeSeconds={initialTimeSeconds}
         score={p1Score}
         spread={-p0Spread}
         playing={playing}


### PR DESCRIPTION
to 1/5 of initial time, or 30sec, whichever is higher.

so instead of at 3min, the clock turns yellow at
- for 2min games or shorter, at 30sec
- for 3min games, at 36sec
- for 4min games, at 48sec
- for 15min games, at 3min
- for 25min games, at 5min

a 1/4+5 game will start in the yellow region, but can reach green region by accumulating more than 30sec.