### PR TITLE
revert match form styling

### DIFF
--- a/liwords-ui/src/lobby/seek_form.scss
+++ b/liwords-ui/src/lobby/seek_form.scss
@@ -66,6 +66,22 @@
       display: none;
     }
   }
+
+  .ant-form-item input, .ant-select-single:not(.ant-select-customize-input) .ant-select-selector .ant-select-selection-search-input {
+    @include colorModed() {
+      background: m($background);
+      color: m($gray-extreme);
+    }
+  }
+  .ant-input-number-input {
+    @include colorModed() {
+      background: m($card-background);
+      color: m($gray-extreme);
+    }
+  }
+  .ant-form-item-control-input {
+    width: 100%;
+  }
   .extra-time-setter, .initial {
     display: flex;
     align-items: center;


### PR DESCRIPTION
this PR just reverts the changes in the secret features PR

https://github.com/domino14/liwords/pull/501/files#diff-0eb4648c210eaf6b9119f3f121f6c463a85c2fdf7abed865b95ba3265684978d

which caused these

<img width="539" alt="Screenshot 2021-04-08 at 22 38 27" src="https://user-images.githubusercontent.com/4179698/114048463-2b710480-98bd-11eb-8754-9c9a9292fa20.png">

<img width="536" alt="Screenshot 2021-04-08 at 22 38 34" src="https://user-images.githubusercontent.com/4179698/114048450-28761400-98bd-11eb-80a1-36909dd93e39.png">
