### PR TITLE
Create auto-analyze toggle to not have to click the lightbulb every turn

### DIFF
--- a/liwords-ui/src/base.scss
+++ b/liwords-ui/src/base.scss
@@ -325,6 +325,11 @@ ul {
     color: m($gray-extreme);
   }
 }
+.ant-switch-checked {
+  @include colorModed() {
+    background: m($primary-midDark);
+  }
+}
 .ant-input-number-input {
   @include colorModed() {
     background: m($card-background);

--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -165,7 +165,7 @@ export const analyzerMoveFromJsonMove = (
 
 const AnalyzerContext = React.createContext<{
   autoMode: boolean;
-  setAutoMode: (a: boolean) => void;
+  setAutoMode: React.Dispatch<React.SetStateAction<boolean>>;
   cachedMoves: Array<AnalyzerMove> | null;
   examinerLoading: boolean;
   requestAnalysis: (lexicon: string) => void;
@@ -178,7 +178,7 @@ const AnalyzerContext = React.createContext<{
   requestAnalysis: (lexicon: string) => {},
   showMovesForTurn: -1,
   setShowMovesForTurn: (a: number) => {},
-  setAutoMode: (a: boolean) => {},
+  setAutoMode: () => {},
 });
 
 export const AnalyzerContextProvider = ({
@@ -404,8 +404,8 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
   ]);
 
   const toggleAutoMode = useCallback(() => {
-    setAutoMode(!autoMode);
-  }, [autoMode, setAutoMode]);
+    setAutoMode((autoMode) => !autoMode);
+  }, [setAutoMode]);
   // Let ExaminableStore activate this.
   useEffect(() => {
     addHandleExaminer(handleExaminer);
@@ -450,7 +450,27 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
       )) ?? null,
     [moves, placeMove]
   );
-
+  const analyzerControls = (
+    <div className="analyzer-controls">
+      <Button
+        className="analyze-trigger"
+        shape="circle"
+        icon={<BulbOutlined />}
+        type="primary"
+        onClick={handleExaminer}
+        disabled={autoMode || examinerLoading}
+      />
+      <div className="auto-controls">
+        <p className="auto-label">Auto</p>
+        <Switch
+          checked={autoMode}
+          onChange={toggleAutoMode}
+          className="auto-toggle"
+          size="small"
+        />
+      </div>
+    </div>
+  );
   const analyzerContainer = (
     <div className="analyzer-container">
       {!examinerLoading ? (
@@ -464,56 +484,12 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
           <RedoOutlined spin />
         </div>
       )}
-      {!props.includeCard ? (
-        <div className="analyzer-controls">
-          <Button
-            className="analyze-trigger"
-            shape="circle"
-            icon={<BulbOutlined />}
-            type="primary"
-            onClick={handleExaminer}
-            disabled={autoMode || examinerLoading}
-          />
-          <div>
-            <p className="auto-label">Auto</p>
-            <Switch
-              checked={autoMode}
-              onChange={toggleAutoMode}
-              className="auto-toggle"
-              size="small"
-            />
-          </div>
-        </div>
-      ) : null}
+      {!props.includeCard ? analyzerControls : null}
     </div>
   );
   if (props.includeCard) {
     return (
-      <Card
-        title="Analyzer"
-        className="analyzer-card"
-        extra={
-          <>
-            <div className="analyzer-controls">
-              <p className="auto-label">Auto</p>
-              <Switch
-                checked={autoMode}
-                onChange={toggleAutoMode}
-                className="auto-toggle"
-                size="small"
-              />
-            </div>
-            <Button
-              className="analyze-trigger"
-              shape="circle"
-              icon={<BulbOutlined />}
-              type="primary"
-              onClick={handleExaminer}
-              disabled={autoMode || examinerLoading}
-            />
-          </>
-        }
-      >
+      <Card title="Analyzer" className="analyzer-card" extra={analyzerControls}>
         {analyzerContainer}
       </Card>
     );

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -118,6 +118,16 @@ p.streak-loss {
         }
       }
     }
+    .ant-card-extra {
+      .analyzer-controls {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        .analyze-trigger {
+          order: 2;
+        }
+      }
+    }
     .ant-card-body {
       padding: 12px;
       height: 240px;
@@ -1304,9 +1314,6 @@ p.rune {
           line-height: 1.5em;
           font-size: 14px;
         }
-        .ant-card-extra {
-          font-size: 14px;
-        }
       }
     }
     .notepad-card, .analyzer-card {
@@ -1323,14 +1330,6 @@ p.rune {
       }
     }
     .analyzer-card {
-      .ant-card-extra {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        .analyzer-controls {
-          flex-direction: row;
-        }
-      }
       .ant-card-body {
         padding: 0;
 

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -143,12 +143,26 @@ p.streak-loss {
         height: 100%;
         align-items: center;
         justify-content: center;
+        .analyze-trigger {
+          margin-left: 0px;
+        }
         .suggestions {
           max-height: 244px;
           overflow-y: auto;
         }
       }
     }
+  }
+  .auto-label {
+    display: inline-block;
+    font-size: 14px;
+    margin-right: 6px;
+    @include colorModed() {
+      color: m($gray-medium);
+    }
+  }
+  .analyze-trigger {
+    margin-left: 12px;
   }
   .analyzer-container {
     .anticon.anticon-redo {
@@ -158,6 +172,7 @@ p.streak-loss {
         color: m($gray-medium);
       }
     }
+
     .suggestions {
       font-family: $font-monospaced;
       width: 100%;
@@ -1199,8 +1214,13 @@ p.rune {
         .anticon.anticon-redo {
           margin-bottom: 0;
         }
+        .analyzer-controls {
+          align-items: center;
+          display: flex;
+          flex-direction: column;
+        }
         .suggestions {
-          width: calc(100% - 60px);
+          width: calc(100% - 90px);
           overflow-y: auto;
           table {
             align-self: flex-start;
@@ -1303,8 +1323,17 @@ p.rune {
       }
     }
     .analyzer-card {
+      .ant-card-extra {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        .analyzer-controls {
+          flex-direction: row;
+        }
+      }
       .ant-card-body {
         padding: 0;
+
         .analyzer-container {
           .suggestions {
             font-size: 13px;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6097979/114342832-d7169080-9b19-11eb-8a5d-06ab857b350b.png)
![image](https://user-images.githubusercontent.com/6097979/114342853-e72e7000-9b19-11eb-8a51-1b11863b957f.png)

Auto-analyze state lives in the analyzer context, so it persists if you change screen size.