### PR TITLE
This should allow any square image type to be uploaded...

### DIFF
--- a/liwords-ui/src/settings/close_account.tsx
+++ b/liwords-ui/src/settings/close_account.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const CloseAccount = React.memo((props: Props) => {
   return (
     <div className="close-account">
-      <h3>Close account</h3>
+      <h3>Delete account</h3>
       <div className="avatar-container">
         <PlayerAvatar player={props.player} />
         <div className="full-name">{props.player?.full_name}</div>
@@ -78,7 +78,7 @@ export const CloseAccount = React.memo((props: Props) => {
           <Col span={12}>
             <Form.Item>
               <Button className="close-account-button" htmlType="submit">
-                Yes, close my account
+                Yes, delete my account
               </Button>
             </Form.Item>
           </Col>

--- a/liwords-ui/src/settings/personal_info.tsx
+++ b/liwords-ui/src/settings/personal_info.tsx
@@ -121,7 +121,9 @@ export const PersonalInfo = React.memo((props: Props) => {
           } else {
             canvas.width = 96;
             canvas.height = 96;
-            canvas.getContext('2d')?.drawImage(image, 0, 0, width, height);
+            canvas
+              .getContext('2d')
+              ?.drawImage(image, 0, 0, image.width, image.height, 0, 0, 96, 96);
             // The endpoint doesn't want the file type data so cut that off
             const jpegString = canvas.toDataURL('image/jpeg', 1).split(',')[1];
             setUploadPending(true);

--- a/liwords-ui/src/settings/personal_info.tsx
+++ b/liwords-ui/src/settings/personal_info.tsx
@@ -54,14 +54,17 @@ export const PersonalInfo = React.memo((props: Props) => {
   );
   const [bioTipsModalVisible, setBioTipsModalVisible] = useState(false);
   const [avatarErr, setAvatarErr] = useState('');
+  const [uploadPending, setUploadPending] = useState(false);
   const avatarErrorCatcher = useCallback((e: AxiosError) => {
     if (e.response) {
       // From Twirp
       console.log(e);
       setAvatarErr(e.response.data.msg);
+      setUploadPending(false);
     } else {
       setAvatarErr('unknown error, see console');
       console.log(e);
+      setUploadPending(false);
     }
   }, []);
   const propsUpdatedAvatar = props.updatedAvatar;
@@ -121,6 +124,7 @@ export const PersonalInfo = React.memo((props: Props) => {
             canvas.getContext('2d')?.drawImage(image, 0, 0, width, height);
             // The endpoint doesn't want the file type data so cut that off
             const jpegString = canvas.toDataURL('image/jpeg', 1).split(',')[1];
+            setUploadPending(true);
             axios
               .post(
                 toAPIUrl('user_service.ProfileService', 'UpdateAvatar'),
@@ -136,6 +140,7 @@ export const PersonalInfo = React.memo((props: Props) => {
                   message: 'Success',
                   description: 'Your avatar was updated.',
                 });
+                setUploadPending(false);
                 propsUpdatedAvatar(resp.data.avatar_url);
               })
               .catch(avatarErrorCatcher);
@@ -253,7 +258,9 @@ export const PersonalInfo = React.memo((props: Props) => {
         <div className="no-avatar-section">
           {' '}
           <Upload {...fileProps}>
-            <Button className="change-avatar">Add a Profile photo</Button>
+            <Button className="change-avatar" disabled={uploadPending}>
+              {uploadPending ? 'Uploading...' : 'Add a Profile photo'}
+            </Button>
           </Upload>
         </div>
       )}
@@ -330,7 +337,7 @@ export const PersonalInfo = React.memo((props: Props) => {
             props.startClosingAccount();
           }}
         >
-          Close my account
+          Delete my account
         </Col>
         <Col span={16}>
           <Form.Item>

--- a/liwords-ui/src/settings/personal_info.tsx
+++ b/liwords-ui/src/settings/personal_info.tsx
@@ -113,7 +113,7 @@ export const PersonalInfo = React.memo((props: Props) => {
           const canvas = document.createElement('canvas'),
             width = image.width,
             height = image.height;
-          if (width < 96 || width != height) {
+          if (width < 96 || width !== height) {
             setAvatarErr('Image must be square and at least 96x96.');
           } else {
             canvas.width = 96;

--- a/liwords-ui/src/settings/secret.tsx
+++ b/liwords-ui/src/settings/secret.tsx
@@ -35,7 +35,14 @@ export const Secret = React.memo((props: Props) => {
       <div className="secret-warning">
         Please use these secret, experimental features at your own discretion.
         They may be limited in functionality and/or impact your Woogles user
-        experience.
+        experience.{' '}
+        <a
+          href="https://github.com/domino14/liwords/wiki/Secret-features"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn More.
+        </a>
       </div>
       <div>
         <div className="toggle-section">

--- a/liwords-ui/src/settings/settings.scss
+++ b/liwords-ui/src/settings/settings.scss
@@ -10,6 +10,9 @@
   line-height: 20px;
   display: flex;
   justify-content: center;
+  .ant-alert {
+    margin-top: 12px;
+  }
   h3 {
     font-family: $font-default;
     font-weight: bold;


### PR DESCRIPTION
… and then resize it and send a 96x96 jpeg version to the server. It will show an error (and not try to send) if the image is too small or not square. I can't test locally because no AWS keys. Also fixes a bug where if people were getting an error the system would just keep trying to send the first one to the server again.

Please try with svg, png, gif as well as jpg.