### PR TITLE
simplify avatar code

### DIFF
--- a/liwords-ui/src/chat/chat_entity.tsx
+++ b/liwords-ui/src/chat/chat_entity.tsx
@@ -16,7 +16,6 @@ import {
 import { ExclamationCircleOutlined } from '@ant-design/icons';
 import { moderateUser, deleteChatMessage } from '../mod/moderate';
 import { PlayerAvatar } from '../shared/player_avatar';
-import { useBriefProfile } from '../utils/brief_profiles';
 
 type EntityProps = {
   entityType: ChatEntityType;
@@ -59,7 +58,6 @@ export const ChatEntity = (props: EntityProps) => {
     excludedPlayersFetched,
   } = useExcludedPlayersStoreContext();
   const { moderators, admins } = useModeratorStoreContext();
-  const briefProfile = useBriefProfile(props.senderId);
   if (props.timestamp) {
     if (
       moment(Date.now()).format('MMM Do') !==
@@ -113,7 +111,7 @@ export const ChatEntity = (props: EntityProps) => {
         <div className="chat-entity">
           <PlayerAvatar
             player={{
-              avatar_url: briefProfile?.getAvatarUrl(),
+              user_id: props.senderId,
             }}
             username={props.sender}
           />

--- a/liwords-ui/src/chat/players.tsx
+++ b/liwords-ui/src/chat/players.tsx
@@ -6,7 +6,6 @@ import {
   useLoginStateStoreContext,
   usePresenceStoreContext,
 } from '../store/store';
-import { useBriefProfile } from '../utils/brief_profiles';
 import { PlayerAvatar } from '../shared/player_avatar';
 import { moderateUser } from '../mod/moderate';
 import { Form, Input } from 'antd';
@@ -32,8 +31,6 @@ type PlayerProps = {
 };
 
 const Player = React.memo((props: PlayerProps) => {
-  const profile = useBriefProfile(props.uuid);
-
   const online = props.fromChat || (props.channel && props.channel?.length > 0);
   let inGame =
     props.channel && props.channel.some((c) => c.includes('chat.game.'));
@@ -51,7 +48,6 @@ const Player = React.memo((props: PlayerProps) => {
     >
       <PlayerAvatar
         player={{
-          avatar_url: profile?.getAvatarUrl(),
           user_id: props.uuid,
           nickname: props.username,
         }}

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -42,7 +42,7 @@ import {
   StreakInfoResponse,
 } from './game_info';
 import { BoopSounds } from '../sound/boop';
-import { postBinary, toAPIUrl, twirpErrToMsg } from '../api/api';
+import { toAPIUrl } from '../api/api';
 import { StreakWidget } from './streak_widget';
 import {
   GameEvent,
@@ -57,10 +57,6 @@ import { readyForTournamentGame } from '../store/reducers/tournament_reducer';
 import { CompetitorStatus } from '../tournament/competitor_status';
 import { Unrace } from '../utils/unrace';
 import { Blank } from '../utils/cwgame/common';
-import {
-  UsersGameInfoRequest,
-  UsersGameInfoResponse,
-} from '../gen/api/proto/user_service/user_service_pb';
 import { useTourneyMetadata } from '../tournament/utils';
 
 type Props = {
@@ -209,7 +205,6 @@ export const Table = React.memo((props: Props) => {
   const competitorState = tournamentContext.competitorState;
   const isRegistered = competitorState.isRegistered;
   const [playerNames, setPlayerNames] = useState(new Array<string>());
-  const [needAvatars, setNeedAvatars] = useState(false);
   const { sendSocketMsg } = props;
   // const location = useLocation();
   const [gameInfo, setGameInfo] = useState<GameMetadata>(defaultGameInfo);
@@ -217,44 +212,6 @@ export const Table = React.memo((props: Props) => {
     streak: [],
   });
   const [isObserver, setIsObserver] = useState(false);
-
-  const getAvatarData = useCallback(async () => {
-    const req = new UsersGameInfoRequest();
-    req.setUuidsList(gameInfo.players.map((p) => p.user_id));
-    try {
-      const rbin = await postBinary(
-        'user_service.ProfileService',
-        'GetUsersGameInfo',
-        req
-      );
-      const resp = UsersGameInfoResponse.deserializeBinary(
-        rbin.data
-      ).toObject();
-      setNeedAvatars(false);
-      const players = [...gameInfo.players];
-      resp.infosList.forEach((info) => {
-        if (info.avatarUrl.length) {
-          const index = gameInfo.players.findIndex(
-            (p) => p.user_id === info.uuid
-          );
-          if (index >= 0) {
-            players[index] = {
-              ...players[index],
-              avatar_url: info.avatarUrl,
-            };
-          }
-        }
-      });
-      setGameInfo({ ...gameInfo, players: players });
-    } catch (err) {
-      message.error({
-        content: `Failed to fetch player information; please refresh. (Error: ${twirpErrToMsg(
-          err
-        )})`,
-        duration: 10,
-      });
-    }
-  }, [gameInfo]);
 
   useEffect(() => {
     // Prevent backspace unless we're in an input element. We don't want to
@@ -317,7 +274,6 @@ export const Table = React.memo((props: Props) => {
       )
       .then((resp) => {
         setGameInfo(resp.data);
-        setNeedAvatars(true);
         if (localStorage?.getItem('poolFormat')) {
           setPoolFormat(
             parseInt(localStorage.getItem('poolFormat') || '0', 10)
@@ -343,13 +299,6 @@ export const Table = React.memo((props: Props) => {
     // React Hook useEffect has missing dependencies: 'setGameEndMessage' and 'setPoolFormat'.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameID]);
-
-  useEffect(() => {
-    if (!gameInfo.game_id || !needAvatars) {
-      return;
-    }
-    getAvatarData();
-  }, [gameInfo, getAvatarData, needAvatars]);
 
   useTourneyMetadata(
     '',

--- a/liwords-ui/src/lobby/sought_games.tsx
+++ b/liwords-ui/src/lobby/sought_games.tsx
@@ -53,7 +53,6 @@ export const PlayerDisplay = (props: PlayerProps) => {
     <div className="player-display">
       <PlayerAvatar
         player={{
-          avatar_url: profile?.getAvatarUrl(),
           user_id: props.userID,
           nickname: props.username,
         }}

--- a/liwords-ui/src/shared/player_avatar.tsx
+++ b/liwords-ui/src/shared/player_avatar.tsx
@@ -3,6 +3,7 @@ import { fixedCharAt } from '../utils/cwgame/common';
 import './avatar.scss';
 import { Tooltip } from 'antd';
 import { PlayerMetadata } from '../gameroom/game_info';
+import { useBriefProfile } from '../utils/brief_profiles';
 const colors = require('../base.scss');
 
 type AvatarProps = {
@@ -13,6 +14,13 @@ type AvatarProps = {
 };
 
 export const PlayerAvatar = (props: AvatarProps) => {
+  // Do not useBriefProfile if avatar_url is explicitly passed in as "".
+  const givenAvatarUrl = props.player?.avatar_url;
+  const profile = useBriefProfile(
+    givenAvatarUrl != null ? undefined : props.player?.user_id
+  );
+  const avatarUrl = givenAvatarUrl ?? profile?.getAvatarUrl();
+
   let avatarStyle = {};
 
   if (props.player?.first) {
@@ -21,15 +29,15 @@ export const PlayerAvatar = (props: AvatarProps) => {
     };
   }
 
-  if (props.player?.avatar_url) {
+  if (avatarUrl) {
     avatarStyle = {
-      backgroundImage: `url(${props.player?.avatar_url})`,
+      backgroundImage: `url(${avatarUrl})`,
     };
   }
 
   const renderAvatar = (
     <div className="player-avatar" style={avatarStyle}>
-      {!props.player?.avatar_url
+      {!avatarUrl
         ? fixedCharAt(
             props.player?.full_name ||
               props.player?.nickname ||


### PR DESCRIPTION
this PR:
- makes the `PlayerAvatar` component use `useBriefProfile` (introduced in #524) directly.
- stops calling the GetUsersGameInfo endpoint (#417), which is returning AvatarUrl and Title (we are not using Title yet). we are already calling GetBriefProfiles for the flags, and that endpoint is already returning avatar urls too for free.
- fixes the bug where "All chats" is not showing avatars. (see image below)
- allows overriding with an explicit `avatar_url: ""` in case we really really want to not show an avatar. (this may not be in use because we no longer edit avatars from profile page.)

<img width="148" alt="Screenshot 2021-05-12 at 14 40 24" src="https://user-images.githubusercontent.com/4179698/117933090-c84b1580-b333-11eb-88d2-44c3331421e4.png">

future:
- completely remove the GetUsersGameInfo endpoint from the backend.
- refactor `DisplayFlag` component similarly (have it take user's uuid, like `DisplayFlagForUUID` below, instead of the country code). this can only be done after #596 is settled.
- add more fields to GetBriefProfiles endpoint as needed.
- adapt GetBriefProfiles for child mode.

https://github.com/domino14/liwords/blob/1d51b9086e1afbf9a3b14a16fc271c50a1593155/liwords-ui/src/chat/chat_channels.tsx#L136-L145

note that it is perfectly fine to have different fine-grained components (one showing just the avatar, one showing just the flag) for the same user, or (for chat) for that same user to appear many times on the same page. the `useBriefProfile` hook is designed specifically to support this, and will deduplicate and make just one combined API call. don't worry!