### PR TITLE
show extra stuffs on seek form

### DIFF
--- a/liwords-ui/src/lobby/seek_form.scss
+++ b/liwords-ui/src/lobby/seek_form.scss
@@ -53,7 +53,9 @@
   }
   .ant-form-item-explain,
   .ant-form-item-extra {
-    display: none;
+    @include colorModed() {
+      color: m($gray-extreme);
+    }
   }
   .ant-form-item-with-help {
     margin-bottom: 24px;


### PR DESCRIPTION
reinstate the missing extras ("regular" and "minutes") by reverting https://github.com/domino14/liwords/pull/584/files#diff-0eb4648c210eaf6b9119f3f121f6c463a85c2fdf7abed865b95ba3265684978dL55-R56

<img width="462" alt="Screenshot 2021-05-15 at 01 37 39" src="https://user-images.githubusercontent.com/4179698/118308124-2d625f00-b51e-11eb-9b96-c5a1601244a8.png">