### PR TITLE
streak patch for long username

### DIFF
--- a/liwords-ui/src/gameroom/streak_widget.tsx
+++ b/liwords-ui/src/gameroom/streak_widget.tsx
@@ -113,6 +113,12 @@ export const StreakWidget = React.memo((props: Props) => {
       );
     });
 
+  const pStyle = {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as 'nowrap',
+  };
+
   return (
     <Card style={{ marginTop: 10 }}>
       <Row>
@@ -120,9 +126,9 @@ export const StreakWidget = React.memo((props: Props) => {
           {pergame}
         </Col>
         <Col span={6}>
-          <div style={{ marginLeft: 20, display: 'inline-block' }}>
-            <p>{first}</p>
-            <p>{second}</p>
+          <div style={{ marginLeft: 20 }}>
+            <p style={pStyle}>{first}</p>
+            <p style={pStyle}>{second}</p>
           </div>
         </Col>
         <Col span={2}>


### PR DESCRIPTION
turn
<img width="154" alt="Screenshot 2021-05-15 at 16 38 52" src="https://user-images.githubusercontent.com/4179698/118354131-24b06e00-b59c-11eb-9e5e-e9a5165354cb.png">

into
<img width="153" alt="Screenshot 2021-05-15 at 16 38 09" src="https://user-images.githubusercontent.com/4179698/118354133-28dc8b80-b59c-11eb-8fc5-bab0f3173233.png">