### PR TITLE
make name-based avatar initial work more often

### DIFF
--- a/liwords-ui/src/profile/profile.tsx
+++ b/liwords-ui/src/profile/profile.tsx
@@ -282,6 +282,7 @@ export const UserProfile = React.memo((props: Props) => {
   const player = {
     avatar_url: avatarUrl,
     full_name: fullName,
+    user_id: userID, // for name-based avatar initial to work
   };
 
   const avatarEditable = avatarsEditable && viewer === username;

--- a/liwords-ui/src/settings/settings.tsx
+++ b/liwords-ui/src/settings/settings.tsx
@@ -75,7 +75,7 @@ const getInitialCategory = (categoryShortcut: string, loggedIn: boolean) => {
 
 export const Settings = React.memo((props: Props) => {
   const { loginState } = useLoginStateStoreContext();
-  const { username: viewer, loggedIn } = loginState;
+  const { userID, username: viewer, loggedIn } = loginState;
   const { useState } = useMountedState();
   const { resetStore } = useResetStoreContext();
   const { section } = useParams();
@@ -124,6 +124,7 @@ export const Settings = React.memo((props: Props) => {
         setPlayer({
           avatar_url: resp.data.avatar_url,
           full_name: resp.data.full_name,
+          user_id: userID, // for name-based avatar initial to work
         });
         setBirthDate(resp.data.birth_date);
         setFirstName(resp.data.first_name);

--- a/liwords-ui/src/shared/player_avatar.tsx
+++ b/liwords-ui/src/shared/player_avatar.tsx
@@ -13,10 +13,12 @@ type AvatarProps = {
   editable?: boolean;
 };
 
+// XXX: AvatarProps should probably not be based on game info's struct.
 export const PlayerAvatar = (props: AvatarProps) => {
   // Do not useBriefProfile if avatar_url is explicitly passed in as "".
   const profile = useBriefProfile(props.player?.user_id);
   const avatarUrl = props.player?.avatar_url ?? profile?.getAvatarUrl();
+  const username = props.username ?? profile?.getUsername();
 
   let avatarStyle = {};
 
@@ -36,10 +38,7 @@ export const PlayerAvatar = (props: AvatarProps) => {
     <div className="player-avatar" style={avatarStyle}>
       {!avatarUrl
         ? fixedCharAt(
-            profile?.getFullName() ||
-              props.player?.nickname ||
-              props.username ||
-              '?',
+            profile?.getFullName() || props.player?.nickname || username || '?',
             0,
             1
           )


### PR DESCRIPTION
this PR fixes:
- when a non-child has a full name but no avatar, the initial on profile screen was based on username. changed this to use the non-child's full name, this was correct in most other screens (such as chat and game).
- when a user has no avatar, the avatar in settings/log out page showed "?". changed this to use full name (if given and non-child) or username (otherwise).

debts remaining unfixed: (anyone can contribute)
- we should probably unify GetPersonalInfo with GetProfile.
- PlayerAvatar uses a struct based on the game info, this is misleading and difficult to work with. note that PlayerAvatar should not take full name, we cannot directly use that full name because of birth date restriction.
- PlayerAvatar only really needs a userid (it uses brief profiles to work out the rest), except for the settings page where the avatar being configured should be shown instead of the cached avatar. the userid should be a mandatory param so that typescript can completely fix this issue.