### PR TITLE
use debounce hook

### DIFF
--- a/liwords-ui/src/chat/chat_channels.tsx
+++ b/liwords-ui/src/chat/chat_channels.tsx
@@ -9,7 +9,7 @@ import {
 } from '../store/store';
 import { useMountedState } from '../utils/mounted';
 import { toAPIUrl } from '../api/api';
-import { debounce } from '../utils/debounce';
+import { useDebounce } from '../utils/debounce';
 import { ActiveChatChannels } from '../gen/api/proto/user_service/user_service_pb';
 import { PlayerAvatar } from '../shared/player_avatar';
 import { DisplayUserFlag } from '../shared/display_flag';
@@ -155,7 +155,7 @@ export const ChatChannels = React.memo((props: Props) => {
       });
   }, []);
 
-  const searchUsernameDebounced = debounce(onUsernameSearch, 300);
+  const searchUsernameDebounced = useDebounce(onUsernameSearch, 300);
 
   const handleUsernameSelect = useCallback(
     (data) => {

--- a/liwords-ui/src/chat/players.tsx
+++ b/liwords-ui/src/chat/players.tsx
@@ -13,7 +13,7 @@ import { UsernameWithContext } from '../shared/usernameWithContext';
 import './playerList.scss';
 import axios from 'axios';
 import { toAPIUrl } from '../api/api';
-import { debounce } from '../utils/debounce';
+import { useDebounce } from '../utils/debounce';
 import { useMountedState } from '../utils/mounted';
 
 type Props = {
@@ -129,7 +129,7 @@ export const Players = React.memo((props: Props) => {
     },
     [username, friends]
   );
-  const searchUsernameDebounced = debounce(onPlayerSearch, 200);
+  const searchUsernameDebounced = useDebounce(onPlayerSearch, 200);
 
   const handleSearchChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -23,7 +23,7 @@ import {
 import { MatchUser } from '../gen/api/proto/realtime/realtime_pb';
 import { SoughtGame } from '../store/reducers/lobby_reducer';
 import { toAPIUrl } from '../api/api';
-import { debounce } from '../utils/debounce';
+import { useDebounce } from '../utils/debounce';
 import { fixedSettings } from './fixed_seek_controls';
 import { ChallengeRulesFormItem } from './challenge_rules_form_item';
 import {
@@ -244,7 +244,7 @@ export const SeekForm = (props: Props) => {
     [defaultOptions]
   );
 
-  const searchUsernameDebounced = debounce(onUsernameSearch, 300);
+  const searchUsernameDebounced = useDebounce(onUsernameSearch, 300);
 
   const onFormSubmit = (val: Store) => {
     const receiver = new MatchUser();

--- a/liwords-ui/src/tournament/add_player_form.tsx
+++ b/liwords-ui/src/tournament/add_player_form.tsx
@@ -2,7 +2,7 @@ import { Button, Form, InputNumber, Select } from 'antd';
 import React, { useCallback } from 'react';
 import axios from 'axios';
 
-import { debounce } from '../utils/debounce';
+import { useDebounce } from '../utils/debounce';
 import { toAPIUrl } from '../api/api';
 import { AutoComplete } from 'antd';
 import { useMountedState } from '../utils/mounted';
@@ -52,7 +52,7 @@ export const AddPlayerForm = (props: Props) => {
       });
   }, []);
 
-  const searchUsernameDebounced = debounce(onUsernameSearch, 300);
+  const searchUsernameDebounced = useDebounce(onUsernameSearch, 300);
 
   const onFormSubmit = (val: Store) => {
     const playersCopy = { ...playersToAdd };

--- a/liwords-ui/src/utils/debounce.ts
+++ b/liwords-ui/src/utils/debounce.ts
@@ -1,12 +1,18 @@
+import { useCallback, useRef } from 'react';
+
+// evolved from
 // https://www.matthewgerstman.com/tech/throttle-and-debounce/
 
-export function debounce(func: Function, timeout: number) {
-  let timer: NodeJS.Timeout;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (...args: any) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      func(...args);
-    }, timeout);
-  };
+export function useDebounce(func: Function, timeout: number) {
+  const timer = useRef<NodeJS.Timeout>();
+  const debounced = useCallback(
+    (...args) => {
+      if (timer.current != null) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        func(...args);
+      }, timeout);
+    },
+    [func, timeout]
+  );
+  return debounced;
 }


### PR DESCRIPTION
debounce() always created a new function/closure. since a rerender always returned a different closure with its own timer, debounce didn't always cancel the previous function's delayed execution.

this PR provides a useDebounce hook that reuses the same timer even when returning a different closure, fixing the bug. if the timeout is unchanged and func has a stable identity (it's from useCallback of which dependencies have not changed), useDebounce would return the same closure, reducing rerendering cost.