### PR TITLE
handle default board/tile

### DIFF
--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -162,7 +162,7 @@ export const Preferences = React.memo((props: Props) => {
       .split(' ')
       .filter((c) => !c.includes('tile--'));
     document.body.className = classes.join(' ').trim();
-    if (tileStyle !== 'default') {
+    if (tileStyle) {
       localStorage.setItem('userTile', tileStyle);
       document?.body?.classList?.add(`tile--${tileStyle}`);
     } else {
@@ -176,7 +176,7 @@ export const Preferences = React.memo((props: Props) => {
       .split(' ')
       .filter((c) => !c.includes('board--'));
     document.body.className = classes.join(' ').trim();
-    if (boardStyle !== 'default') {
+    if (boardStyle) {
       localStorage.setItem('userBoard', boardStyle);
       document?.body?.classList?.add(`board--${boardStyle}`);
     } else {

--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -160,7 +160,7 @@ export const Preferences = React.memo((props: Props) => {
   const handleUserTileChange = useCallback((tileStyle: string) => {
     const classes = document?.body?.className
       .split(' ')
-      .filter((c) => !c.includes('tile--'));
+      .filter((c) => !c.startsWith('tile--'));
     document.body.className = classes.join(' ').trim();
     if (tileStyle) {
       localStorage.setItem('userTile', tileStyle);
@@ -174,7 +174,7 @@ export const Preferences = React.memo((props: Props) => {
   const handleUserBoardChange = useCallback((boardStyle: string) => {
     const classes = document?.body?.className
       .split(' ')
-      .filter((c) => !c.includes('board--'));
+      .filter((c) => !c.startsWith('board--'));
     document.body.className = classes.join(' ').trim();
     if (boardStyle) {
       localStorage.setItem('userBoard', boardStyle);

--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -138,10 +138,10 @@ export const Preferences = React.memo((props: Props) => {
   const [darkMode, setDarkMode] = useState(
     localStorage?.getItem('darkMode') === 'true'
   );
-  const initialTileStyle = localStorage?.getItem('userTile') || 'default';
+  const initialTileStyle = localStorage?.getItem('userTile') || 'Default';
   const [userTile, setUserTile] = useState<string>(initialTileStyle);
 
-  const initialBoardStyle = localStorage?.getItem('userBoard') || 'default';
+  const initialBoardStyle = localStorage?.getItem('userBoard') || 'Default';
   const [userBoard, setUserBoard] = useState<string>(initialBoardStyle);
 
   const toggleDarkMode = useCallback(() => {


### PR DESCRIPTION
- (visibly) change default to Default to fix https://github.com/domino14/liwords/pull/580/files#r624619886 (image below)
- fix the test for default (the one in #562/#580 wasn't working before; selecting something else and then selecting default, added "tile--"/"board--" to body class, and set the localStorage to "", instead of actually removing both). it was getting the value instead of the name, so it should compare against empty string
- use .startsWith to check for class names to be removed, instead of .includes

<img width="97" alt="Screenshot 2021-05-02 at 13 14 13" src="https://user-images.githubusercontent.com/4179698/116802782-5c54fa00-ab48-11eb-9023-f390685db8e1.png">
