### PR TITLE
Add overflow-wrap to wrap long words (e.g. links)

### DIFF
--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -317,7 +317,7 @@ p {
       }
       .message {
         line-height: normal;
-        overflow-wrap: anywhere;
+        overflow-wrap: break-word;
       }
       .player-avatar {
         width: 36px;

--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -317,6 +317,7 @@ p {
       }
       .message {
         line-height: normal;
+        overflow-wrap: anywhere;
       }
       .player-avatar {
         width: 36px;


### PR DESCRIPTION
This avoids creating a horizontal scroll bar when someone sends a long word in chat