### PR TITLE
Introduce word wrap to chat window

### DIFF
--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -317,7 +317,8 @@ p {
       }
       .message {
         line-height: normal;
-        overflow-wrap: break-word;
+        overflow-wrap: anywhere;
+        word-break: break-word;
       }
       .player-avatar {
         width: 36px;

--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -317,6 +317,7 @@ p {
       }
       .message {
         line-height: normal;
+        overflow-wrap: break-word;
       }
       .player-avatar {
         width: 36px;


### PR DESCRIPTION
Stop long words (e.g. links) from extending chat window