### PR TITLE
exclude tab titles from scrolling

### DIFF
--- a/liwords-ui/src/lobby/gameLists.tsx
+++ b/liwords-ui/src/lobby/gameLists.tsx
@@ -303,29 +303,29 @@ export const GameLists = React.memo((props: Props) => {
   return (
     <div className="game-lists">
       <Card actions={actions}>
-        <div className="main-content">
-          <div className="tabs">
-            {loggedIn ? (
-              <div
-                onClick={() => {
-                  setSelectedGameTab('PLAY');
-                }}
-                className={selectedGameTab === 'PLAY' ? 'tab active' : 'tab'}
-              >
-                Play
-              </div>
-            ) : null}
+        <div className="tabs">
+          {loggedIn ? (
             <div
               onClick={() => {
-                setSelectedGameTab('WATCH');
+                setSelectedGameTab('PLAY');
               }}
-              className={
-                selectedGameTab === 'WATCH' || !loggedIn ? 'tab active' : 'tab'
-              }
+              className={selectedGameTab === 'PLAY' ? 'tab active' : 'tab'}
             >
-              Watch
+              Play
             </div>
+          ) : null}
+          <div
+            onClick={() => {
+              setSelectedGameTab('WATCH');
+            }}
+            className={
+              selectedGameTab === 'WATCH' || !loggedIn ? 'tab active' : 'tab'
+            }
+          >
+            Watch
           </div>
+        </div>
+        <div className="main-content">
           {renderGames()}
           {seekModal}
           {matchModal}

--- a/liwords-ui/src/tournament/actions_panel.tsx
+++ b/liwords-ui/src/tournament/actions_panel.tsx
@@ -446,50 +446,48 @@ export const ActionsPanel = React.memo((props: Props) => {
             : 'free-form'
         }
       >
-        <div className="main-content">
-          <div className="tabs">
+        <div className="tabs">
+          <div
+            onClick={() => {
+              setSelectedGameTab('GAMES');
+            }}
+            className={selectedGameTab === 'GAMES' ? 'tab active' : 'tab'}
+          >
+            Games
+          </div>
+          {!isPairedMode(tournamentContext.metadata?.getType()) ? (
             <div
               onClick={() => {
-                setSelectedGameTab('GAMES');
+                setSelectedGameTab('RECENT');
               }}
-              className={selectedGameTab === 'GAMES' ? 'tab active' : 'tab'}
+              className={selectedGameTab === 'RECENT' ? 'tab active' : 'tab'}
             >
-              Games
+              Recent games
             </div>
-            {!isPairedMode(tournamentContext.metadata?.getType()) ? (
-              <div
-                onClick={() => {
-                  setSelectedGameTab('RECENT');
-                }}
-                className={selectedGameTab === 'RECENT' ? 'tab active' : 'tab'}
-              >
-                Recent games
-              </div>
-            ) : (
-              <div
-                onClick={() => {
-                  setSelectedGameTab('STANDINGS');
-                }}
-                className={
-                  selectedGameTab === 'STANDINGS' ? 'tab active' : 'tab'
-                }
-              >
-                Standings
-              </div>
-            )}
-            {isDirector && (
-              <div
-                onClick={() => {
-                  setSelectedGameTab('DIRECTOR TOOLS');
-                }}
-                className={
-                  selectedGameTab === 'DIRECTOR TOOLS' ? 'tab active' : 'tab'
-                }
-              >
-                Director Tools
-              </div>
-            )}
-          </div>
+          ) : (
+            <div
+              onClick={() => {
+                setSelectedGameTab('STANDINGS');
+              }}
+              className={selectedGameTab === 'STANDINGS' ? 'tab active' : 'tab'}
+            >
+              Standings
+            </div>
+          )}
+          {isDirector && (
+            <div
+              onClick={() => {
+                setSelectedGameTab('DIRECTOR TOOLS');
+              }}
+              className={
+                selectedGameTab === 'DIRECTOR TOOLS' ? 'tab active' : 'tab'
+              }
+            >
+              Director Tools
+            </div>
+          )}
+        </div>
+        <div className="main-content">
           {isDirector &&
             selectedGameTab === 'DIRECTOR TOOLS' &&
             renderDirectorTools()}


### PR DESCRIPTION
move tabs out of the scrollable main-content. (center panel only)

this makes it easier to switch between "play"/"watch" (lobby) and "games"/"recent games"/"standings"/"director tools" (club/tournament) after scrolling through a long content.

(review with ?w=1, there's nothing much to it)