### PR TITLE
faster rack tapping

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -642,6 +642,7 @@ p.streak-loss {
 /* Rack */
 
 .rack {
+  touch-action: manipulation;
   display: flex;
   justify-content: center;
   align-items: center;


### PR DESCRIPTION
[disable double-tap-to-zoom on mobile](https://developer.mozilla.org/en-US/docs/Web/CSS/touch-action)