### PR TITLE
use valid equity loss only

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -644,6 +644,11 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
     () => localStorage.getItem('enableShowEquityLoss') === 'true',
     []
   );
+  const equityBase = React.useMemo(
+    () =>
+      showEquityLoss ? moves?.find((x) => x.valid ?? true)?.equity ?? 0 : 0,
+    [moves, showEquityLoss]
+  );
   const renderAnalyzerMoves = useMemo(
     () =>
       moves?.map((m: AnalyzerMove, idx) => (
@@ -659,12 +664,12 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
           <td className="move-score">{m.score}</td>
           <td className="move-leave">{m.leave}</td>
           <td className="move-equity">
-            {(m.equity - (showEquityLoss ? moves[0].equity : 0)).toFixed(2)}
+            {(m.equity - equityBase).toFixed(2)}
             {!(m.valid ?? true) && <React.Fragment>*</React.Fragment>}
           </td>
         </tr>
       )) ?? null,
-    [moves, placeMove, showEquityLoss]
+    [equityBase, moves, placeMove]
   );
   const analyzerControls = (
     <div className="analyzer-controls">


### PR DESCRIPTION
if "show equity loss" is enabled and the actual played move is a phony, the equity loss was relative to that phony.

this fixes it so that the equity loss is relative to the top valid play instead. (the phony has equity loss of the opposite sign)