### PR TITLE
remove letter offset

### DIFF
--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -709,19 +709,6 @@ p.streak-loss {
   text-align: center;
   width: $tile-size-mobile;
   height: $tile-size-mobile;
-  &[data-rune="Q"] {
-    p.rune {
-      position: relative;
-      left: -2px;
-    }
-  }
-  &[data-rune="Z"] {
-    p.rune {
-      position: relative;
-      left: -1px;
-    }
-  }
-
 }
 .tile {
   @include colorModed() {
@@ -894,11 +881,11 @@ p.rune {
 .tile .point-value {
   position: absolute;
   bottom: 5px;
-  right: 0;
+  right: 0.15em;
   padding: 3px 2px;
   line-height: 0;
   margin: 0;
-  letter-spacing: -0.1em;
+  letter-spacing: -0.25em;
   font-size: $point-size-mobile;
   font-weight: bold;
   @include colorModed() {
@@ -1536,16 +1523,6 @@ p.rune {
   .empty-space {
     height: $tile-size-laptop;
     width: $tile-size-laptop;
-    &[data-rune="Q"] {
-      p.rune {
-        left: -2px;
-      }
-    }
-    &[data-rune="Z"] {
-      p.rune {
-        left: -1px;
-      }
-    }
   }
   .tile.droppable {
     pointer-events: all;


### PR DESCRIPTION
need ux approval

currently Q and Z are offset to accommodate 10 pt, this makes reading vertical words slower
<img width="179" alt="Screenshot 2021-06-10 at 13 04 59" src="https://user-images.githubusercontent.com/4179698/121468005-b3be7380-c9ec-11eb-9311-ff0cd4293e93.png">

this removes the offset and adjusts the letter-spacing
<img width="180" alt="Screenshot 2021-06-10 at 13 04 44" src="https://user-images.githubusercontent.com/4179698/121468029-bb7e1800-c9ec-11eb-8bd4-562ba6d6a4e2.png">

and make it unnecessary to be language-aware (other-language tiles have the 10-pt on different letters)