### PR TITLE
fix notepad buttons

### DIFF
--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -16,7 +16,7 @@ import {
   contiguousTilesFromTileSet,
   simpletile,
 } from '../utils/cwgame/scoring';
-import { Direction, isMobile } from '../utils/cwgame/common';
+import { Direction, EmptySpace, isMobile } from '../utils/cwgame/common';
 import { useMountedState } from '../utils/mounted';
 import { BoopSounds } from '../sound/boop';
 
@@ -71,7 +71,11 @@ export const Notepad = React.memo((props: NotepadProps) => {
     const contiguousTiles = contiguousTilesFromTileSet(placedTiles, board);
     let play = '';
     let position = '';
-    const leave = sortTiles(displayedRack);
+    const leave = sortTiles(
+      Array.from(displayedRack)
+        .filter((x) => x !== EmptySpace)
+        .join('')
+    );
     if (contiguousTiles?.length === 2) {
       position = humanReadablePosition(
         contiguousTiles[1],

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -103,7 +103,9 @@ export const Notepad = React.memo((props: NotepadProps) => {
     setCurNotepad(
       (curNotepad) =>
         `${curNotepad ? curNotepad + '\n' : ''}${
-          play ? `${position} ${play} ${placedTilesTempScore} ` : ''
+          play
+            ? `${position} ${play} ${placedTilesTempScore}${leave ? ' ' : ''}`
+            : ''
         }${leave}`
     );
     // Return focus to board on all but mobile so the key commands can be used immediately

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -103,8 +103,8 @@ export const Notepad = React.memo((props: NotepadProps) => {
     setCurNotepad(
       (curNotepad) =>
         `${curNotepad ? curNotepad + '\n' : ''}${
-          play ? position + ' ' + play + ' ' : ''
-        }${placedTilesTempScore ? placedTilesTempScore + ' ' : ''}${leave}`
+          play ? `${position} ${play} ${placedTilesTempScore} ` : ''
+        }${leave}`
     );
     // Return focus to board on all but mobile so the key commands can be used immediately
     if (!isMobile()) {

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -111,6 +111,9 @@ export const Notepad = React.memo((props: NotepadProps) => {
       document.getElementById('board-container')?.focus();
     }
   }, [displayedRack, placedTiles, placedTilesTempScore, setCurNotepad, board]);
+  const clearNotepad = useCallback(() => {
+    setCurNotepad('');
+  }, [setCurNotepad]);
   useEffect(() => {
     if (notepadEl.current && !(notepadEl.current === document.activeElement)) {
       notepadEl.current.scrollTop = notepadEl.current.scrollHeight || 0;
@@ -135,18 +138,17 @@ export const Notepad = React.memo((props: NotepadProps) => {
     }
     numWolgesWas.current = numWolges;
   }, [numWolges]);
+  const notepadIsNotEmpty = curNotepad.length > 0;
   const controls = useCallback(
     () => (
       <React.Fragment>
         {easterEggEnabled && <EasterEgg />}
-        {curNotepad.length > 0 && (
+        {notepadIsNotEmpty && (
           <Button
             shape="circle"
             icon={<DeleteOutlined />}
             type="primary"
-            onClick={() => {
-              setCurNotepad('');
-            }}
+            onClick={clearNotepad}
           />
         )}
         <Button
@@ -157,7 +159,7 @@ export const Notepad = React.memo((props: NotepadProps) => {
         />
       </React.Fragment>
     ),
-    [curNotepad, easterEggEnabled, setCurNotepad, addPlay]
+    [easterEggEnabled, notepadIsNotEmpty, clearNotepad, addPlay]
   );
   const notepadContainer = (
     <div className="notepad-container" style={props.style}>

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -71,7 +71,7 @@ export const Notepad = React.memo((props: NotepadProps) => {
     const contiguousTiles = contiguousTilesFromTileSet(placedTiles, board);
     let play = '';
     let position = '';
-    const leave = sortTiles(displayedRack.split('').sort().join(''));
+    const leave = sortTiles(displayedRack);
     if (contiguousTiles?.length === 2) {
       position = humanReadablePosition(
         contiguousTiles[1],

--- a/liwords-ui/src/gameroom/notepad.tsx
+++ b/liwords-ui/src/gameroom/notepad.tsx
@@ -39,7 +39,9 @@ const humanReadablePosition = (
 
 const NotepadContext = React.createContext({
   curNotepad: '',
-  setCurNotepad: (a: string) => {},
+  setCurNotepad: ((a: string) => {}) as React.Dispatch<
+    React.SetStateAction<string>
+  >,
 });
 
 export const NotepadContextProvider = ({
@@ -99,22 +101,16 @@ export const Notepad = React.memo((props: NotepadProps) => {
       if (inParen) play += ')';
     }
     setCurNotepad(
-      `${curNotepad ? curNotepad + '\n' : ''}${
-        play ? position + ' ' + play + ' ' : ''
-      }${placedTilesTempScore ? placedTilesTempScore + ' ' : ''}${leave}`
+      (curNotepad) =>
+        `${curNotepad ? curNotepad + '\n' : ''}${
+          play ? position + ' ' + play + ' ' : ''
+        }${placedTilesTempScore ? placedTilesTempScore + ' ' : ''}${leave}`
     );
     // Return focus to board on all but mobile so the key commands can be used immediately
     if (!isMobile()) {
       document.getElementById('board-container')?.focus();
     }
-  }, [
-    displayedRack,
-    placedTiles,
-    placedTilesTempScore,
-    curNotepad,
-    setCurNotepad,
-    board,
-  ]);
+  }, [displayedRack, placedTiles, placedTilesTempScore, setCurNotepad, board]);
   useEffect(() => {
     if (notepadEl.current && !(notepadEl.current === document.activeElement)) {
       notepadEl.current.scrollTop = notepadEl.current.scrollHeight || 0;


### PR DESCRIPTION
- optimize to not double sort (previously it sorted alphabetically before re-sorting by preferred order)
- exclude empty space from rack leave in notepad (fixes #705 by ignoring spaces introduced in #678)
- reuse add play handler (previously a new handler was created every time notepad content changed)
- reuse clear notepad handler (previously a new handler and a new button were created every time notepad content changed, now use one handler and only recreate the button when the notepad toggles from empty to non-empty)
- fix missing score in notepad when placing a blank next to another for zero points (this is an existing bug, because 0 is also falsy)
- remove trailing space if leave is empty (previously when adding plays that emptied the rack there would still be a space after the score)