### PR TITLE
unconfuse slider

### DIFF
--- a/liwords-ui/src/lobby/fixed_seek_controls.ts
+++ b/liwords-ui/src/lobby/fixed_seek_controls.ts
@@ -9,7 +9,7 @@ import {
 export type seekPropVals = {
   lexicon: string;
   challengerule: ChallengeRuleMap[keyof ChallengeRuleMap];
-  initialtime: number;
+  initialtimeslider: number;
   rated: boolean;
   extratime: number;
   friend: string;
@@ -21,7 +21,7 @@ export type seekPropVals = {
 type hardcodedSeekPropVals = Partial<seekPropVals> &
   Pick<
     seekPropVals,
-    'initialtime' | 'rated' | 'extratime' | 'incOrOT' | 'variant'
+    'initialtimeslider' | 'rated' | 'extratime' | 'incOrOT' | 'variant'
   > &
   Partial<{
     lexicon: 'CSW19' | 'CSW19X' | 'NSWL20' | 'NWL20'; // add more only as needed
@@ -32,7 +32,7 @@ const phillyvirtual: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.VOID,
-  initialtime: 22, // Slider position is equivalent to 20 minutes.
+  initialtimeslider: 22, // Slider position is equivalent to 20 minutes.
   rated: true,
   extratime: 2,
   friend: '',
@@ -44,7 +44,7 @@ const cococlub: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 17, // 15 minutes
+  initialtimeslider: 17, // 15 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -56,7 +56,7 @@ const laclub: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.DOUBLE,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 3,
   friend: '',
@@ -67,7 +67,7 @@ const laclub: hardcodedSeekPropVals = {
 const madisonclub: hardcodedSeekPropVals = {
   variant: 'classic',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -79,7 +79,7 @@ const cocoblitz: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 5, // 3 minutes
+  initialtimeslider: 5, // 3 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -91,7 +91,7 @@ const channel275: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -103,7 +103,7 @@ const nssg: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19X',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 15, // 13 minutes
+  initialtimeslider: 15, // 13 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -114,20 +114,20 @@ const nssg: hardcodedSeekPropVals = {
 const nssg16: hardcodedSeekPropVals = {
   variant: 'classic',
   ...nssg,
-  initialtime: 18, // 16 mins
+  initialtimeslider: 18, // 16 mins
 };
 
 const nssg19: hardcodedSeekPropVals = {
   variant: 'classic',
   ...nssg,
-  initialtime: 21, // 19 mins
+  initialtimeslider: 21, // 19 mins
 };
 
 const phillyasap: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.VOID,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 2,
   friend: '',
@@ -139,7 +139,7 @@ const nyc: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.DOUBLE,
-  initialtime: 19, // 17 minutes
+  initialtimeslider: 19, // 17 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -149,7 +149,7 @@ const nyc: hardcodedSeekPropVals = {
 
 const learners: hardcodedSeekPropVals = {
   variant: 'classic',
-  initialtime: 12, // 10 minutes
+  initialtimeslider: 12, // 10 minutes
   rated: true,
   extratime: 0,
   friend: '',
@@ -161,7 +161,7 @@ const nasscChampionship: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -173,7 +173,7 @@ const nasscNovice: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.VOID,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -185,7 +185,7 @@ const nasscHighSchool: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.DOUBLE,
-  initialtime: 22, // 20 minutes
+  initialtimeslider: 22, // 20 minutes
   rated: true,
   extratime: 1,
   friend: '',
@@ -197,7 +197,7 @@ const premiumswerve: hardcodedSeekPropVals = {
   variant: 'wordsmog',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtime: 24, // 22 minutes
+  initialtimeslider: 24, // 22 minutes
   rated: true,
   extratime: 1,
   friend: '',

--- a/liwords-ui/src/lobby/fixed_seek_controls.ts
+++ b/liwords-ui/src/lobby/fixed_seek_controls.ts
@@ -1,6 +1,8 @@
 // Note: this is a TEMPORARY file. Once we add this ability to the tournament
 // backend, we can remove this.
 
+import { initialTimeMinutesToSlider } from '../store/constants';
+
 import {
   ChallengeRule,
   ChallengeRuleMap,
@@ -32,7 +34,7 @@ const phillyvirtual: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.VOID,
-  initialtimeslider: 22, // Slider position is equivalent to 20 minutes.
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 2,
   friend: '',
@@ -44,7 +46,7 @@ const cococlub: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 17, // 15 minutes
+  initialtimeslider: initialTimeMinutesToSlider(15),
   rated: true,
   extratime: 1,
   friend: '',
@@ -56,7 +58,7 @@ const laclub: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.DOUBLE,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 3,
   friend: '',
@@ -67,7 +69,7 @@ const laclub: hardcodedSeekPropVals = {
 const madisonclub: hardcodedSeekPropVals = {
   variant: 'classic',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 1,
   friend: '',
@@ -79,7 +81,7 @@ const cocoblitz: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 5, // 3 minutes
+  initialtimeslider: initialTimeMinutesToSlider(3),
   rated: true,
   extratime: 1,
   friend: '',
@@ -91,7 +93,7 @@ const channel275: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 1,
   friend: '',
@@ -103,7 +105,7 @@ const nssg: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19X',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 15, // 13 minutes
+  initialtimeslider: initialTimeMinutesToSlider(13),
   rated: true,
   extratime: 1,
   friend: '',
@@ -114,20 +116,20 @@ const nssg: hardcodedSeekPropVals = {
 const nssg16: hardcodedSeekPropVals = {
   variant: 'classic',
   ...nssg,
-  initialtimeslider: 18, // 16 mins
+  initialtimeslider: initialTimeMinutesToSlider(16),
 };
 
 const nssg19: hardcodedSeekPropVals = {
   variant: 'classic',
   ...nssg,
-  initialtimeslider: 21, // 19 mins
+  initialtimeslider: initialTimeMinutesToSlider(19),
 };
 
 const phillyasap: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.VOID,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 2,
   friend: '',
@@ -139,7 +141,7 @@ const nyc: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.DOUBLE,
-  initialtimeslider: 19, // 17 minutes
+  initialtimeslider: initialTimeMinutesToSlider(17),
   rated: true,
   extratime: 1,
   friend: '',
@@ -149,7 +151,7 @@ const nyc: hardcodedSeekPropVals = {
 
 const learners: hardcodedSeekPropVals = {
   variant: 'classic',
-  initialtimeslider: 12, // 10 minutes
+  initialtimeslider: initialTimeMinutesToSlider(10),
   rated: true,
   extratime: 0,
   friend: '',
@@ -161,7 +163,7 @@ const nasscChampionship: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 1,
   friend: '',
@@ -173,7 +175,7 @@ const nasscNovice: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.VOID,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 1,
   friend: '',
@@ -185,7 +187,7 @@ const nasscHighSchool: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.DOUBLE,
-  initialtimeslider: 22, // 20 minutes
+  initialtimeslider: initialTimeMinutesToSlider(20),
   rated: true,
   extratime: 1,
   friend: '',
@@ -197,7 +199,7 @@ const premiumswerve: hardcodedSeekPropVals = {
   variant: 'wordsmog',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
-  initialtimeslider: 24, // 22 minutes
+  initialtimeslider: initialTimeMinutesToSlider(22),
   rated: true,
   extratime: 1,
   friend: '',

--- a/liwords-ui/src/lobby/fixed_seek_controls.ts
+++ b/liwords-ui/src/lobby/fixed_seek_controls.ts
@@ -1,11 +1,34 @@
 // Note: this is a TEMPORARY file. Once we add this ability to the tournament
 // backend, we can remove this.
 
-import { ChallengeRule } from '../gen/macondo/api/proto/macondo/macondo_pb';
+import {
+  ChallengeRule,
+  ChallengeRuleMap,
+} from '../gen/macondo/api/proto/macondo/macondo_pb';
 
-type settings = { [key: string]: string | number | boolean };
+export type seekPropVals = {
+  lexicon: string;
+  challengerule: ChallengeRuleMap[keyof ChallengeRuleMap];
+  initialtime: number;
+  rated: boolean;
+  extratime: number;
+  friend: string;
+  incOrOT: 'overtime' | 'increment';
+  vsBot: boolean;
+  variant: string;
+};
 
-const phillyvirtual = {
+type hardcodedSeekPropVals = Partial<seekPropVals> &
+  Pick<
+    seekPropVals,
+    'initialtime' | 'rated' | 'extratime' | 'incOrOT' | 'variant'
+  > &
+  Partial<{
+    lexicon: 'CSW19' | 'CSW19X' | 'NSWL20' | 'NWL20'; // add more only as needed
+    variant: 'classic' | 'wordsmog';
+  }>;
+
+const phillyvirtual: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.VOID,
@@ -17,7 +40,7 @@ const phillyvirtual = {
   vsBot: false,
 };
 
-const cococlub = {
+const cococlub: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
@@ -29,7 +52,7 @@ const cococlub = {
   vsBot: false,
 };
 
-const laclub = {
+const laclub: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.DOUBLE,
@@ -41,7 +64,7 @@ const laclub = {
   vsBot: false,
 };
 
-const madisonclub = {
+const madisonclub: hardcodedSeekPropVals = {
   variant: 'classic',
   challengerule: ChallengeRule.FIVE_POINT,
   initialtime: 22, // 20 minutes
@@ -52,7 +75,7 @@ const madisonclub = {
   vsBot: false,
 };
 
-const cocoblitz = {
+const cocoblitz: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
@@ -64,7 +87,7 @@ const cocoblitz = {
   vsBot: false,
 };
 
-const channel275 = {
+const channel275: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
@@ -76,7 +99,7 @@ const channel275 = {
   vsBot: false,
 };
 
-const nssg = {
+const nssg: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'CSW19X',
   challengerule: ChallengeRule.FIVE_POINT,
@@ -88,19 +111,19 @@ const nssg = {
   vsBot: false,
 };
 
-const nssg16 = {
+const nssg16: hardcodedSeekPropVals = {
   variant: 'classic',
   ...nssg,
   initialtime: 18, // 16 mins
 };
 
-const nssg19 = {
+const nssg19: hardcodedSeekPropVals = {
   variant: 'classic',
   ...nssg,
   initialtime: 21, // 19 mins
 };
 
-const phillyasap = {
+const phillyasap: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.VOID,
@@ -112,7 +135,7 @@ const phillyasap = {
   vsBot: false,
 };
 
-const nyc = {
+const nyc: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NWL20',
   challengerule: ChallengeRule.DOUBLE,
@@ -124,7 +147,7 @@ const nyc = {
   vsBot: false,
 };
 
-const learners = {
+const learners: hardcodedSeekPropVals = {
   variant: 'classic',
   initialtime: 12, // 10 minutes
   rated: true,
@@ -134,7 +157,7 @@ const learners = {
   vsBot: false,
 };
 
-const nasscChampionship = {
+const nasscChampionship: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.FIVE_POINT,
@@ -146,7 +169,7 @@ const nasscChampionship = {
   vsBot: false,
 };
 
-const nasscNovice = {
+const nasscNovice: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.VOID,
@@ -158,7 +181,7 @@ const nasscNovice = {
   vsBot: false,
 };
 
-const nasscHighSchool = {
+const nasscHighSchool: hardcodedSeekPropVals = {
   variant: 'classic',
   lexicon: 'NSWL20',
   challengerule: ChallengeRule.DOUBLE,
@@ -170,7 +193,7 @@ const nasscHighSchool = {
   vsBot: false,
 };
 
-const premiumswerve = {
+const premiumswerve: hardcodedSeekPropVals = {
   variant: 'wordsmog',
   lexicon: 'CSW19',
   challengerule: ChallengeRule.FIVE_POINT,
@@ -182,7 +205,7 @@ const premiumswerve = {
   vsBot: false,
 };
 
-export const fixedSettings: { [key: string]: settings } = {
+export const fixedSettings: { [key: string]: hardcodedSeekPropVals } = {
   phillyvirtual,
   cococlub,
   madisonclub,

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -16,6 +16,7 @@ import { Store } from 'antd/lib/form/interface';
 import { useMountedState } from '../utils/mounted';
 import { ChallengeRule } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import {
+  initialTimeMinutesToSlider,
   initTimeDiscreteScale,
   timeCtrlToDisplayName,
 } from '../store/constants';
@@ -106,7 +107,7 @@ export const SeekForm = (props: Props) => {
   const defaultValues: seekPropVals = {
     lexicon: 'CSW19',
     challengerule: ChallengeRule.FIVE_POINT,
-    initialtimeslider: 22, // Note this isn't minutes, but the slider position.
+    initialtimeslider: initialTimeMinutesToSlider(20),
     rated: true,
     extratime: 1,
     friend: '',

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -18,7 +18,6 @@ import { ChallengeRule } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import {
   initTimeDiscreteScale,
   timeCtrlToDisplayName,
-  timeScaleToNum,
 } from '../store/constants';
 import { MatchUser } from '../gen/api/proto/realtime/realtime_pb';
 import { SoughtGame } from '../store/reducers/lobby_reducer';
@@ -33,7 +32,7 @@ import {
 import { VariantIcon } from '../shared/variant_icons';
 
 const initTimeFormatter = (val?: number) => {
-  return initTimeDiscreteScale[val!];
+  return val != null ? initTimeDiscreteScale[val].label : null;
 };
 
 type user = {
@@ -159,7 +158,7 @@ export const SeekForm = (props: Props) => {
     };
   }
   const [itc, itt] = timeCtrlToDisplayName(
-    timeScaleToNum(initTimeDiscreteScale[initialValues.initialtimeslider]) * 60,
+    initTimeDiscreteScale[initialValues.initialtimeslider].seconds,
     initialValues.incOrOT === 'increment'
       ? Math.round(initialValues.extratime as number)
       : 0,
@@ -204,7 +203,7 @@ export const SeekForm = (props: Props) => {
       setExtraTimeLabel(otUnitLabel);
     }
     const [tc, tt] = timeCtrlToDisplayName(
-      timeScaleToNum(initTimeDiscreteScale[allvals.initialtimeslider]) * 60,
+      initTimeDiscreteScale[allvals.initialtimeslider].seconds,
       allvals.incOrOT === 'increment'
         ? Math.round(allvals.extratime as number)
         : 0,
@@ -274,8 +273,7 @@ export const SeekForm = (props: Props) => {
         (val.lexicon as string) === 'ECWL'
           ? ChallengeRule.VOID
           : (val.challengerule as number),
-      initialTimeSecs:
-        timeScaleToNum(initTimeDiscreteScale[val.initialtimeslider]) * 60,
+      initialTimeSecs: initTimeDiscreteScale[val.initialtimeslider].seconds,
       incrementSecs:
         val.incOrOT === 'increment' ? Math.round(val.extratime as number) : 0,
       rated: val.rated as boolean,

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -24,14 +24,13 @@ import { MatchUser } from '../gen/api/proto/realtime/realtime_pb';
 import { SoughtGame } from '../store/reducers/lobby_reducer';
 import { toAPIUrl } from '../api/api';
 import { useDebounce } from '../utils/debounce';
-import { fixedSettings } from './fixed_seek_controls';
+import { fixedSettings, seekPropVals } from './fixed_seek_controls';
 import { ChallengeRulesFormItem } from './challenge_rules_form_item';
 import {
   useFriendsStoreContext,
   usePresenceStoreContext,
 } from '../store/store';
 import { VariantIcon } from '../shared/variant_icons';
-export type seekPropVals = { [val: string]: string | number | boolean };
 
 const initTimeFormatter = (val?: number) => {
   return initTimeDiscreteScale[val!];

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -107,7 +107,7 @@ export const SeekForm = (props: Props) => {
   const defaultValues: seekPropVals = {
     lexicon: 'CSW19',
     challengerule: ChallengeRule.FIVE_POINT,
-    initialtime: 22, // Note this isn't minutes, but the slider position.
+    initialtimeslider: 22, // Note this isn't minutes, but the slider position.
     rated: true,
     extratime: 1,
     friend: '',
@@ -159,7 +159,7 @@ export const SeekForm = (props: Props) => {
     };
   }
   const [itc, itt] = timeCtrlToDisplayName(
-    timeScaleToNum(initTimeDiscreteScale[initialValues.initialtime]) * 60,
+    timeScaleToNum(initTimeDiscreteScale[initialValues.initialtimeslider]) * 60,
     initialValues.incOrOT === 'increment'
       ? Math.round(initialValues.extratime as number)
       : 0,
@@ -204,7 +204,7 @@ export const SeekForm = (props: Props) => {
       setExtraTimeLabel(otUnitLabel);
     }
     const [tc, tt] = timeCtrlToDisplayName(
-      timeScaleToNum(initTimeDiscreteScale[allvals.initialtime]) * 60,
+      timeScaleToNum(initTimeDiscreteScale[allvals.initialtimeslider]) * 60,
       allvals.incOrOT === 'increment'
         ? Math.round(allvals.extratime as number)
         : 0,
@@ -275,7 +275,7 @@ export const SeekForm = (props: Props) => {
           ? ChallengeRule.VOID
           : (val.challengerule as number),
       initialTimeSecs:
-        timeScaleToNum(initTimeDiscreteScale[val.initialtime]) * 60,
+        timeScaleToNum(initTimeDiscreteScale[val.initialtimeslider]) * 60,
       incrementSecs:
         val.incOrOT === 'increment' ? Math.round(val.extratime as number) : 0,
       rated: val.rated as boolean,
@@ -401,7 +401,7 @@ export const SeekForm = (props: Props) => {
       <Form.Item
         className="initial"
         label="Initial minutes"
-        name="initialtime"
+        name="initialtimeslider"
         extra={<Tag color={ttag}>{timectrl}</Tag>}
       >
         <Slider

--- a/liwords-ui/src/store/constants.ts
+++ b/liwords-ui/src/store/constants.ts
@@ -48,20 +48,7 @@ export const timeCtrlToDisplayName = (
   return ['Regular', 'blue'];
 };
 
-export const timeScaleToNum = (val: string) => {
-  switch (val) {
-    case '¼':
-      return 0.25;
-    case '½':
-      return 0.5;
-    case '¾':
-      return 0.75;
-    default:
-      return parseInt(val, 10);
-  }
-};
-
-export const initialTimeLabel = (secs: number) => {
+const initialTimeLabel = (secs: number) => {
   let initTLabel;
   switch (secs) {
     case 15:
@@ -79,24 +66,16 @@ export const initialTimeLabel = (secs: number) => {
   return initTLabel;
 };
 
-const wholetimes = [];
-for (let i = 1; i <= 25; i++) {
-  wholetimes.push(i.toString());
-}
-
 export const initTimeDiscreteScale = [
-  '¼',
-  '½',
-  '¾',
-  ...wholetimes,
-  '30',
-  '35',
-  '40',
-  '45',
-  '50',
-  '55',
-  '60',
-];
+  15,
+  30,
+  45,
+  ...Array.from(new Array(25), (_, x) => (x + 1) * 60),
+  ...[30, 35, 40, 45, 50, 55, 60].map((x) => x * 60),
+].map((seconds) => ({
+  seconds,
+  label: initialTimeLabel(seconds),
+}));
 
 export const timeToString = (
   secs: number,

--- a/liwords-ui/src/store/constants.ts
+++ b/liwords-ui/src/store/constants.ts
@@ -77,6 +77,15 @@ export const initTimeDiscreteScale = [
   label: initialTimeLabel(seconds),
 }));
 
+export const initialTimeSecondsToSlider = (secs: number) => {
+  const ret = initTimeDiscreteScale.findIndex((x) => x.seconds === secs);
+  if (ret >= 0) return ret;
+  throw new Error(`bad initial time: ${secs} seconds`);
+};
+
+export const initialTimeMinutesToSlider = (mins: number) =>
+  initialTimeSecondsToSlider(mins * 60);
+
 export const timeToString = (
   secs: number,
   incrementSecs: number,

--- a/liwords-ui/src/tournament/game_settings_form.tsx
+++ b/liwords-ui/src/tournament/game_settings_form.tsx
@@ -13,6 +13,7 @@ import { Store } from 'rc-field-form/lib/interface';
 import React from 'react';
 import { ChallengeRule } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import {
+  initialTimeMinutesToSlider,
   initTimeDiscreteScale,
   timeCtrlToDisplayName,
 } from '../store/constants';
@@ -69,7 +70,7 @@ const toFormValues: (gameRequest: GameRequest | null) => mandatoryFormValues = (
       lexicon: 'CSW19',
       variant: 'classic',
       challengerule: ChallengeRule.FIVE_POINT,
-      initialtimeslider: 17, // Note this isn't minutes, but the slider position.
+      initialtimeslider: initialTimeMinutesToSlider(15),
       rated: true,
       extratime: 1,
       incOrOT: 'overtime',

--- a/liwords-ui/src/tournament/game_settings_form.tsx
+++ b/liwords-ui/src/tournament/game_settings_form.tsx
@@ -15,7 +15,6 @@ import { ChallengeRule } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import {
   initTimeDiscreteScale,
   timeCtrlToDisplayName,
-  timeScaleToNum,
 } from '../store/constants';
 import { useMountedState } from '../utils/mounted';
 import { ChallengeRulesFormItem } from '../lobby/challenge_rules_form_item';
@@ -47,7 +46,7 @@ const incUnitLabel = (
 );
 
 const initTimeFormatter = (val?: number) => {
-  return initTimeDiscreteScale[val!];
+  return val != null ? initTimeDiscreteScale[val].label : null;
 };
 
 type mandatoryFormValues = Partial<seekPropVals> &
@@ -110,7 +109,7 @@ export const SettingsForm = (props: Props) => {
   const initialValues = toFormValues(gameRequest);
 
   const [itc, itt] = timeCtrlToDisplayName(
-    timeScaleToNum(initTimeDiscreteScale[initialValues.initialtimeslider]) * 60,
+    initTimeDiscreteScale[initialValues.initialtimeslider].seconds,
     initialValues.incOrOT === 'increment'
       ? Math.round(initialValues.extratime as number)
       : 0,
@@ -141,7 +140,7 @@ export const SettingsForm = (props: Props) => {
       setExtraTimeLabel(otUnitLabel);
     }
     const [tc, tt] = timeCtrlToDisplayName(
-      timeScaleToNum(initTimeDiscreteScale[allvals.initialtimeslider]) * 60,
+      initTimeDiscreteScale[allvals.initialtimeslider].seconds,
       allvals.incOrOT === 'increment'
         ? Math.round(allvals.extratime as number)
         : 0,
@@ -167,7 +166,7 @@ export const SettingsForm = (props: Props) => {
 
     gr.setLexicon(values.lexicon);
     gr.setInitialTimeSeconds(
-      timeScaleToNum(initTimeDiscreteScale[values.initialtimeslider]) * 60
+      initTimeDiscreteScale[values.initialtimeslider].seconds
     );
 
     if (values.incOrOT === 'increment') {

--- a/liwords-ui/src/tournament/game_settings_form.tsx
+++ b/liwords-ui/src/tournament/game_settings_form.tsx
@@ -19,6 +19,7 @@ import {
 } from '../store/constants';
 import { useMountedState } from '../utils/mounted';
 import { ChallengeRulesFormItem } from '../lobby/challenge_rules_form_item';
+import { seekPropVals } from '../lobby/fixed_seek_controls';
 import { VariantIcon } from '../shared/variant_icons';
 import {
   GameMode,
@@ -49,12 +50,26 @@ const initTimeFormatter = (val?: number) => {
   return initTimeDiscreteScale[val!];
 };
 
-const toFormValues = (gameRequest: GameRequest | null) => {
+type mandatoryFormValues = Partial<seekPropVals> &
+  Pick<
+    seekPropVals,
+    | 'lexicon'
+    | 'challengerule'
+    | 'initialtime'
+    | 'rated'
+    | 'extratime'
+    | 'incOrOT'
+    | 'variant'
+  >;
+
+const toFormValues: (gameRequest: GameRequest | null) => mandatoryFormValues = (
+  gameRequest: GameRequest | null
+) => {
   if (!gameRequest) {
     return {
       lexicon: 'CSW19',
       variant: 'classic',
-      challengeRule: ChallengeRule.FIVE_POINT,
+      challengerule: ChallengeRule.FIVE_POINT,
       initialtime: 17, // Note this isn't minutes, but the slider position.
       rated: true,
       extratime: 1,
@@ -62,9 +77,9 @@ const toFormValues = (gameRequest: GameRequest | null) => {
     };
   }
 
-  const vals = {
+  const vals: mandatoryFormValues = {
     lexicon: gameRequest.getLexicon(),
-    variant: gameRequest.getRules()?.getVariantName(),
+    variant: gameRequest.getRules()?.getVariantName() ?? '',
     challengerule: gameRequest.getChallengeRule(),
     rated: gameRequest.getRatingMode() === RatingMode.RATED,
     initialtime: 0,

--- a/liwords-ui/src/tournament/game_settings_form.tsx
+++ b/liwords-ui/src/tournament/game_settings_form.tsx
@@ -55,7 +55,7 @@ type mandatoryFormValues = Partial<seekPropVals> &
     seekPropVals,
     | 'lexicon'
     | 'challengerule'
-    | 'initialtime'
+    | 'initialtimeslider'
     | 'rated'
     | 'extratime'
     | 'incOrOT'
@@ -70,7 +70,7 @@ const toFormValues: (gameRequest: GameRequest | null) => mandatoryFormValues = (
       lexicon: 'CSW19',
       variant: 'classic',
       challengerule: ChallengeRule.FIVE_POINT,
-      initialtime: 17, // Note this isn't minutes, but the slider position.
+      initialtimeslider: 17, // Note this isn't minutes, but the slider position.
       rated: true,
       extratime: 1,
       incOrOT: 'overtime',
@@ -82,7 +82,7 @@ const toFormValues: (gameRequest: GameRequest | null) => mandatoryFormValues = (
     variant: gameRequest.getRules()?.getVariantName() ?? '',
     challengerule: gameRequest.getChallengeRule(),
     rated: gameRequest.getRatingMode() === RatingMode.RATED,
-    initialtime: 0,
+    initialtimeslider: 0,
     extratime: 0,
     incOrOT: 'overtime',
   };
@@ -90,9 +90,9 @@ const toFormValues: (gameRequest: GameRequest | null) => mandatoryFormValues = (
   const secs = gameRequest.getInitialTimeSeconds();
   const mins = secs / 60;
   if (mins >= 1) {
-    vals.initialtime = mins + 2; // magic slider position
+    vals.initialtimeslider = mins + 2; // magic slider position
   } else {
-    vals.initialtime = secs / 15 - 1; // magic slider position
+    vals.initialtimeslider = secs / 15 - 1; // magic slider position
   }
   if (gameRequest.getMaxOvertimeMinutes()) {
     vals.extratime = gameRequest.getMaxOvertimeMinutes();
@@ -110,7 +110,7 @@ export const SettingsForm = (props: Props) => {
   const initialValues = toFormValues(gameRequest);
 
   const [itc, itt] = timeCtrlToDisplayName(
-    timeScaleToNum(initTimeDiscreteScale[initialValues.initialtime]) * 60,
+    timeScaleToNum(initTimeDiscreteScale[initialValues.initialtimeslider]) * 60,
     initialValues.incOrOT === 'increment'
       ? Math.round(initialValues.extratime as number)
       : 0,
@@ -141,7 +141,7 @@ export const SettingsForm = (props: Props) => {
       setExtraTimeLabel(otUnitLabel);
     }
     const [tc, tt] = timeCtrlToDisplayName(
-      timeScaleToNum(initTimeDiscreteScale[allvals.initialtime]) * 60,
+      timeScaleToNum(initTimeDiscreteScale[allvals.initialtimeslider]) * 60,
       allvals.incOrOT === 'increment'
         ? Math.round(allvals.extratime as number)
         : 0,
@@ -167,7 +167,7 @@ export const SettingsForm = (props: Props) => {
 
     gr.setLexicon(values.lexicon);
     gr.setInitialTimeSeconds(
-      timeScaleToNum(initTimeDiscreteScale[values.initialtime]) * 60
+      timeScaleToNum(initTimeDiscreteScale[values.initialtimeslider]) * 60
     );
 
     if (values.incOrOT === 'increment') {
@@ -228,7 +228,7 @@ export const SettingsForm = (props: Props) => {
       <Form.Item
         className="initial"
         label="Initial Minutes"
-        name="initialtime"
+        name="initialtimeslider"
         extra={<Tag color={ttag}>{timectrl}</Tag>}
       >
         <Slider

--- a/liwords-ui/src/tournament/game_settings_form.tsx
+++ b/liwords-ui/src/tournament/game_settings_form.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { ChallengeRule } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import {
   initialTimeMinutesToSlider,
+  initialTimeSecondsToSlider,
   initTimeDiscreteScale,
   timeCtrlToDisplayName,
 } from '../store/constants';
@@ -88,11 +89,13 @@ const toFormValues: (gameRequest: GameRequest | null) => mandatoryFormValues = (
   };
 
   const secs = gameRequest.getInitialTimeSeconds();
-  const mins = secs / 60;
-  if (mins >= 1) {
-    vals.initialtimeslider = mins + 2; // magic slider position
-  } else {
-    vals.initialtimeslider = secs / 15 - 1; // magic slider position
+  try {
+    vals.initialtimeslider = initialTimeSecondsToSlider(secs);
+  } catch (e) {
+    const msg = `cannot find ${secs} seconds in slider`;
+    console.error(msg, e);
+    alert(msg);
+    vals.initialtimeslider = 0;
   }
   if (gameRequest.getMaxOvertimeMinutes()) {
     vals.extratime = gameRequest.getMaxOvertimeMinutes();


### PR DESCRIPTION
#704 
instead of `indexOf`
- add types and fix a bug (`seekPropVals` was a generic object, adding types uncovered a `challengeRule:` that should have been `challengerule:`)
- rename field to avoid confusion (`initialtime` to `initialtimeslider`)
- put duration and label together (`initTimeDiscreteScale` was an array of label strings, turned into `{ seconds: number, label: string}`; this made `timeScaleToNum` unnecessary)
- specify slider const in minutes (by doing linear search on `initTimeDiscreteScale` instead of using hardcoded index positions)
- remove incorrect magic slider position code (by doing linear search on `initTimeDiscreteScale` instead of doing magic slider position; also added `alert` for bad values since this is for directors only)