### PR TITLE
sign up touch up

### DIFF
--- a/liwords-ui/src/lobby/accountForms.scss
+++ b/liwords-ui/src/lobby/accountForms.scss
@@ -45,7 +45,7 @@ div.account {
       padding-bottom: 24px;
       p.no-cheat {
         padding-left: 16px;
-        margin: 12px 0 0 0;
+        margin: 6px 0;
       }
     }
     .ant-row.ant-form-item.password {

--- a/liwords-ui/src/lobby/register.tsx
+++ b/liwords-ui/src/lobby/register.tsx
@@ -4,9 +4,31 @@ import { useMountedState } from '../utils/mounted';
 import axios from 'axios';
 import { TopBar } from '../topbar/topbar';
 import { Input, Form, Button, Alert, Checkbox } from 'antd';
+import { Rule } from 'antd/lib/form';
 import { toAPIUrl } from '../api/api';
 import './accountForms.scss';
 import woogles from '../assets/woogles.png';
+
+const usernameValidator = async (rule: Rule, value: string) => {
+  if (value.length === 0) {
+    throw new Error('Please input your username');
+  }
+  if (value.length < 3) {
+    throw new Error('Min username length is 3');
+  }
+  if (value.length > 20) {
+    throw new Error('Max username length is 20');
+  }
+  if (!/^[0-9a-zA-Z\-_.]+$/.test(value)) {
+    throw new Error('Valid characters are A-Z a-z 0-9 . _ -');
+  }
+  if (!/^[0-9a-zA-Z]/.test(value)) {
+    throw new Error('Valid starting characters are A-Z a-z 0-9');
+  }
+  if (!/[0-9a-zA-Z]$/.test(value)) {
+    throw new Error('Valid ending characters are A-Z a-z 0-9');
+  }
+};
 
 export const Register = () => {
   const { useState } = useMountedState();
@@ -100,28 +122,7 @@ export const Register = () => {
               hasFeedback
               rules={[
                 {
-                  required: true,
-                  message: 'Please input your username',
-                },
-                {
-                  min: 3,
-                  message: 'Min username length is 3',
-                },
-                {
-                  max: 20,
-                  message: 'Max username length is 20',
-                },
-                {
-                  pattern: new RegExp(/^[0-9a-zA-Z\-_.]+$/),
-                  message: 'Valid characters are A-Z a-z 0-9 . _ -',
-                },
-                {
-                  pattern: /^[0-9a-zA-Z]/,
-                  message: 'Valid starting characters are A-Z a-z 0-9',
-                },
-                {
-                  pattern: /[0-9a-zA-Z]$/,
-                  message: 'Valid ending characters are A-Z a-z 0-9',
+                  validator: usernameValidator,
                 },
               ]}
             >

--- a/liwords-ui/src/lobby/register.tsx
+++ b/liwords-ui/src/lobby/register.tsx
@@ -115,6 +115,10 @@ export const Register = () => {
                   pattern: new RegExp(/^[0-9a-zA-Z\-_.]+$/),
                   message: 'Valid characters are A-Z a-z 0-9 . _ -',
                 },
+                {
+                  pattern: /^[0-9a-zA-Z]/,
+                  message: 'Valid starting characters are A-Z a-z 0-9',
+                },
               ]}
             >
               <Input placeholder="Username" maxLength={20} />

--- a/liwords-ui/src/lobby/register.tsx
+++ b/liwords-ui/src/lobby/register.tsx
@@ -119,6 +119,10 @@ export const Register = () => {
                   pattern: /^[0-9a-zA-Z]/,
                   message: 'Valid starting characters are A-Z a-z 0-9',
                 },
+                {
+                  pattern: /[0-9a-zA-Z]$/,
+                  message: 'Valid ending characters are A-Z a-z 0-9',
+                },
               ]}
             >
               <Input placeholder="Username" maxLength={20} />

--- a/pkg/registration/register.go
+++ b/pkg/registration/register.go
@@ -31,6 +31,9 @@ func RegisterUser(ctx context.Context, username string, password string, email s
 	if strings.HasPrefix(username, "-") || strings.HasPrefix(username, ".") || strings.HasPrefix(username, "_") {
 		return errors.New("username must start with a number or a letter")
 	}
+	if strings.HasSuffix(username, "-") || strings.HasSuffix(username, ".") || strings.HasSuffix(username, "_") {
+		return errors.New("username must end with a number or a letter")
+	}
 
 	if len(password) < 8 {
 		return errors.New("your new password is too short, use 8 or more characters")

--- a/pkg/registration/register.go
+++ b/pkg/registration/register.go
@@ -28,7 +28,7 @@ func RegisterUser(ctx context.Context, username string, password string, email s
 	if strings.ToLower(username) == "anonymous" {
 		return errors.New("username is not acceptable")
 	}
-	if strings.HasPrefix(username, ".") || strings.HasPrefix(username, "-") {
+	if strings.HasPrefix(username, "-") || strings.HasPrefix(username, ".") || strings.HasPrefix(username, "_") {
 		return errors.New("username must start with a number or a letter")
 	}
 

--- a/pkg/stores/user/db.go
+++ b/pkg/stores/user/db.go
@@ -845,9 +845,10 @@ func (s *DBStore) UsersByPrefix(ctx context.Context, prefix string) ([]*pb.Basic
 	// package would result in a circular dependency, we cannot
 	// get the string the correct way with ms.ModActionType_SUSPEND_ACCOUNT.String(),
 	// so we hard code it here.
+	lowerPrefix := strings.ToLower(prefix)
 	if result := s.db.Table("users").Select("username, uuid").
-		Where("lower(username) like ? AND internal_bot = ? AND (actions IS NULL OR actions->'Current' IS NULL OR actions->'Current'->'SUSPEND_ACCOUNT' IS NULL OR actions->'Current'->'SUSPEND_ACCOUNT'->'end_time' IS NOT NULL)",
-			strings.ToLower(prefix)+"%", false).
+		Where("substr(lower(username), 1, length(?)) = ? AND internal_bot = ? AND (actions IS NULL OR actions->'Current' IS NULL OR actions->'Current'->'SUSPEND_ACCOUNT' IS NULL OR actions->'Current'->'SUSPEND_ACCOUNT'->'end_time' IS NOT NULL)",
+			lowerPrefix, lowerPrefix, false).
 		Limit(20).
 		Scan(&us); result.Error != nil {
 		return nil, result.Error


### PR DESCRIPTION
#626 
- verifying eligibility
  - backend didn't check for username starting with _, added this check
  - frontend didn't check that username starts with alphanumeric, added this check
  - other discrepancies are backend-only and should probably not be exposed
- error text
  - misconfiguration already fixed, the message should be in english now
- checkbox alignment
  - fixed in here