### PR TITLE
remove peopleOnlineContext

### DIFF
--- a/liwords-ui/src/chat/chat.test.tsx
+++ b/liwords-ui/src/chat/chat.test.tsx
@@ -10,7 +10,6 @@ function renderChat(props: Partial<Props> = {}) {
     return;
   };
   const defaultProps: Props = {
-    peopleOnlineContext: (n) => 'Whatever',
     defaultChannel: 'lobby',
     defaultDescription: 'description',
     sendChat: dummyFunction,

--- a/liwords-ui/src/chat/chat.tsx
+++ b/liwords-ui/src/chat/chat.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { Card, Input, Tabs } from 'antd';
 import { LeftOutlined } from '@ant-design/icons';
 import { useMountedState } from '../utils/mounted';
+import { singularCount } from '../utils/plural';
 import { ChatEntity } from './chat_entity';
 import {
   ChatEntityObj,
@@ -26,7 +27,6 @@ import { Players } from './players';
 const { TabPane } = Tabs;
 
 export type Props = {
-  peopleOnlineContext: (n: number) => string; // should return "1 person" or "2 people"
   sendChat: (msg: string, chan: string) => void;
   defaultChannel: string;
   defaultDescription: string;
@@ -597,6 +597,13 @@ export const Chat = React.memo((props: Props) => {
       checkOpponentPresence.current.count = laggedGameChannelPresenceCount;
     }
   }, [addChat, gameChannel, laggedGameChannelPresenceCount]);
+  const peopleOnlineCounter = useMemo(
+    () =>
+      channel?.startsWith('chat.gametv.')
+        ? singularCount(presenceCount, 'Observer', 'Observers')
+        : singularCount(presenceCount, 'Player', 'Players'),
+    [channel, presenceCount]
+  );
 
   return (
     <Card className="chat" id="chat">
@@ -677,7 +684,7 @@ export const Chat = React.memo((props: Props) => {
                   {presenceCount && !channel.startsWith('chat.pm.') ? (
                     <>
                       <p className="presence-count">
-                        <span>{props.peopleOnlineContext(presenceCount)}</span>
+                        <span>{peopleOnlineCounter}</span>
                         {presenceVisible ? (
                           <span
                             className="list-trigger"

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -49,7 +49,6 @@ import {
   PlayState,
 } from '../gen/macondo/api/proto/macondo/macondo_pb';
 import { endGameMessageFromGameInfo } from '../store/end_of_game';
-import { singularCount } from '../utils/plural';
 import { Notepad, NotepadContextProvider } from './notepad';
 import { Analyzer, AnalyzerContextProvider } from './analyzer';
 import { isClubType, isPairedMode, sortTiles } from '../store/constants';
@@ -914,13 +913,6 @@ export const Table = React.memo((props: Props) => {
     searchParams,
     searchedTurn,
   ]);
-  const peopleOnlineContext = useCallback(
-    (n: number) =>
-      isObserver
-        ? singularCount(n, 'Observer', 'Observers')
-        : singularCount(n, 'Player', 'Players'),
-    [isObserver]
-  );
   const boardTheme =
     'board--' + tournamentContext.metadata.getBoardStyle() || '';
   const tileTheme = 'tile--' + tournamentContext.metadata.getTileStyle() || '';
@@ -990,7 +982,6 @@ export const Table = React.memo((props: Props) => {
                 username,
                 isObserver
               )}
-              peopleOnlineContext={peopleOnlineContext}
               tournamentID={gameInfo.tournament_id}
             />
           ) : null}

--- a/liwords-ui/src/lobby/lobby.tsx
+++ b/liwords-ui/src/lobby/lobby.tsx
@@ -7,7 +7,6 @@ import { SoughtGame } from '../store/reducers/lobby_reducer';
 import { GameLists } from './gameLists';
 import { Chat } from '../chat/chat';
 import { useLoginStateStoreContext } from '../store/store';
-import { singularCount } from '../utils/plural';
 import './lobby.scss';
 import { Announcements } from './announcements';
 import { sendAccept, sendSeek } from './sought_game_interactions';
@@ -46,11 +45,6 @@ export const Lobby = (props: Props) => {
     [sendSocketMsg]
   );
 
-  const peopleOnlineContext = useCallback(
-    (n: number) => singularCount(n, 'Player', 'Players'),
-    []
-  );
-
   return (
     <>
       <TopBar />
@@ -60,7 +54,6 @@ export const Lobby = (props: Props) => {
             sendChat={props.sendChat}
             defaultChannel="chat.lobby"
             defaultDescription="Help chat"
-            peopleOnlineContext={peopleOnlineContext}
             DISCONNECT={props.DISCONNECT}
           />
         </div>

--- a/liwords-ui/src/tournament/room.tsx
+++ b/liwords-ui/src/tournament/room.tsx
@@ -8,7 +8,6 @@ import {
 } from '../store/store';
 import { useMountedState } from '../utils/mounted';
 import { TopBar } from '../topbar/topbar';
-import { singularCount } from '../utils/plural';
 import { Chat } from '../chat/chat';
 import { TournamentInfo } from './tournament_info';
 import { sendAccept, sendSeek } from '../lobby/sought_game_interactions';
@@ -70,11 +69,6 @@ export const TournamentRoom = (props: Props) => {
     [sendSocketMsg]
   );
 
-  const peopleOnlineContext = useCallback(
-    (n: number) => singularCount(n, 'Player', 'Players'),
-    []
-  );
-
   if (badTournament) {
     return (
       <>
@@ -103,7 +97,6 @@ export const TournamentRoom = (props: Props) => {
             sendChat={props.sendChat}
             defaultChannel={`chat.tournament.${tournamentID}`}
             defaultDescription={tournamentContext.metadata.getName()}
-            peopleOnlineContext={peopleOnlineContext}
             highlight={tournamentContext.directors}
             highlightText="Director"
             tournamentID={tournamentID}


### PR DESCRIPTION
when observing a club/tournament game, switching chat to the club/tournament lobby channel incorrectly displayed "x observers" instead of "x players".