### PR TITLE
restrict examine shortcuts

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -805,7 +805,12 @@ export const Analyzer = React.memo((props: AnalyzerProps) => {
   );
   if (props.includeCard) {
     return (
-      <Card title="Analyzer" className="analyzer-card" extra={analyzerControls}>
+      <Card
+        title="Analyzer"
+        className="analyzer-card"
+        extra={analyzerControls}
+        tabIndex={-1} /* enable Examine shortcuts on clicking card title */
+      >
         {analyzerContainer}
       </Card>
     );

--- a/liwords-ui/src/store/store.tsx
+++ b/liwords-ui/src/store/store.tsx
@@ -619,11 +619,7 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
 
   const handleExamineShortcuts = useCallback(
     (evt) => {
-      if (
-        isExamining &&
-        (shouldTrigger(document.activeElement) ||
-          shouldTrigger(window.getSelection()?.focusNode?.parentElement))
-      ) {
+      if (isExamining && shouldTrigger(document.activeElement)) {
         if (evt.ctrlKey || evt.altKey || evt.metaKey) {
           // If a modifier key is held, never mind.
         } else {


### PR DESCRIPTION
possible workaround for firefox's buggy `window.getSelection()?.focusNode` implementation, which claimed that the `.game-controls` was in focus when the chat box actually is, which in turn caused examiner to do things when user types `,` or `.` into chat.