### PR TITLE
some utf8 support

### DIFF
--- a/pkg/bus/event_sanitizer.go
+++ b/pkg/bus/event_sanitizer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"strconv"
+	"unicode/utf8"
 
 	"github.com/golang/protobuf/proto"
 
@@ -51,7 +52,7 @@ func sanitize(us user.Store, evt *entity.EventWrapper, userID string) (*entity.E
 			if evt.Nickname != mynick {
 				evt.Rack = ""
 				if evt.Type == macondopb.GameEvent_EXCHANGE {
-					evt.Exchanged = strconv.Itoa(len(evt.Exchanged))
+					evt.Exchanged = strconv.Itoa(utf8.RuneCountInString(evt.Exchanged))
 				}
 			}
 		}
@@ -82,7 +83,7 @@ func sanitize(us user.Store, evt *entity.EventWrapper, userID string) (*entity.E
 		cloned.NewRack = ""
 		cloned.Event.Rack = ""
 		if cloned.Event.Type == macondopb.GameEvent_EXCHANGE {
-			cloned.Event.Exchanged = strconv.Itoa(len(cloned.Event.Exchanged))
+			cloned.Event.Exchanged = strconv.Itoa(utf8.RuneCountInString(cloned.Event.Exchanged))
 		}
 		return entity.WrapEvent(cloned, pb.MessageType_SERVER_GAMEPLAY_EVENT), nil
 

--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"time"
+	"unicode/utf8"
 
 	"github.com/domino14/macondo/runner"
 
@@ -627,8 +628,9 @@ func sanitizeEvent(sge *pb.ServerGameplayEvent) *pb.ServerGameplayEvent {
 	cloned := proto.Clone(sge).(*pb.ServerGameplayEvent)
 	cloned.NewRack = ""
 	cloned.Event.Rack = ""
+	// len() > 0 is fine
 	if len(cloned.Event.Exchanged) > 0 {
-		cloned.Event.Exchanged = strconv.Itoa(len(cloned.Event.Exchanged))
+		cloned.Event.Exchanged = strconv.Itoa(utf8.RuneCountInString(cloned.Event.Exchanged))
 	}
 	return cloned
 }

--- a/pkg/stats/stats.go
+++ b/pkg/stats/stats.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"unicode"
+	"unicode/utf8"
 
 	"github.com/domino14/liwords/pkg/entity"
 	realtime "github.com/domino14/liwords/rpc/api/proto/realtime"
@@ -956,7 +957,7 @@ func countBonusSquares(info *IncrementInfo,
 }
 
 func isBingoNineOrAbove(event *pb.GameEvent) bool {
-	return event.IsBingo && len(event.PlayedTiles) >= 9
+	return event.IsBingo && utf8.RuneCountInString(event.PlayedTiles) >= 9
 }
 
 func isUnchallengedPhonyEvent(event *pb.GameEvent,


### PR DESCRIPTION
may not be comprehensive.

len(s) counts number of bytes, this affects games in foreign languages.
- "exchange 8" when opponent exchanges Ä
- stats for 9-or-above bingos (which is unused)