### PR TITLE
fix examiner availability

### DIFF
--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -130,6 +130,8 @@ export type Props = {
 
 const GameControls = React.memo((props: Props) => {
   const { useState } = useMountedState();
+  const { gameContext } = useGameContextStoreContext();
+  const gameHasNotStarted = gameContext.players.length === 0; // :shrug:
 
   // Poka-yoke against accidentally having multiple pop-ups active.
   const [actualCurrentPopUp, setCurrentPopUp] = useState<
@@ -261,7 +263,9 @@ const GameControls = React.memo((props: Props) => {
   if (observer) {
     return (
       <div className="game-controls">
-        <Button onClick={props.onExamine}>Examine</Button>
+        <Button onClick={props.onExamine} disabled={gameHasNotStarted}>
+          Examine
+        </Button>
         <Button onClick={handleExitToLobby}>Exit</Button>
       </div>
     );
@@ -339,6 +343,7 @@ const GameControls = React.memo((props: Props) => {
           overlay={optionsMenu}
           trigger={['click']}
           visible={optionsMenuVisible}
+          disabled={gameHasNotStarted}
         >
           <Button onClick={() => setOptionsMenuVisible((v) => !v)}>
             Options <DownOutlined />
@@ -444,15 +449,21 @@ type EGCProps = {
 const EndGameControls = (props: EGCProps) => {
   const { useState } = useMountedState();
   const [rematchDisabled, setRematchDisabled] = useState(false);
+  const { gameContext } = useGameContextStoreContext();
+  const gameHasNotStarted = gameContext.players.length === 0; // :shrug:
 
   return (
     <div className="game-controls">
       <div className="secondary-controls">
         <Button disabled>Options</Button>
-        <Button onClick={props.onExamine}>Examine</Button>
+        <Button onClick={props.onExamine} disabled={gameHasNotStarted}>
+          Examine
+        </Button>
       </div>
       <div className="secondary-controls">
-        <Button onClick={props.onExportGCG}>Export GCG</Button>
+        <Button onClick={props.onExportGCG} disabled={gameHasNotStarted}>
+          Export GCG
+        </Button>
         <Button onClick={props.onExit}>Exit</Button>
       </div>
       {props.showRematch && !props.tournamentPairedMode && !rematchDisabled && (

--- a/liwords-ui/src/gameroom/table.tsx
+++ b/liwords-ui/src/gameroom/table.tsx
@@ -99,7 +99,8 @@ const ManageWindowTitleAndTurnSound = (props: {}) => {
     return myPlayerOrder === 'p0' ? 0 : myPlayerOrder === 'p1' ? 1 : null;
   }, [gameContext.uidToPlayerOrder, userID]);
 
-  const gameDone = gameContext.playState === PlayState.GAME_OVER;
+  const gameDone =
+    gameContext.playState === PlayState.GAME_OVER && !!gameContext.gameID;
 
   // do not play sound when game ends (e.g. resign) or has not loaded
   const canPlaySound = !gameDone && gameContext.gameID;
@@ -243,7 +244,8 @@ export const Table = React.memo((props: Props) => {
     };
   }, []);
 
-  const gameDone = gameContext.playState === PlayState.GAME_OVER;
+  const gameDone =
+    gameContext.playState === PlayState.GAME_OVER && !!gameContext.gameID;
 
   useEffect(() => {
     if (gameDone || isObserver) {

--- a/liwords-ui/src/store/store.tsx
+++ b/liwords-ui/src/store/store.tsx
@@ -589,7 +589,7 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
   }, [shownTimes]);
 
   // There are two handlers (the Tablet view has its own Analyzer button).
-  // Fortunately the second one will do nothing, so we just trigger both.
+  // They are functionally the same.
   const [handleExaminers, setHandleExaminers] = useState(
     new Array<() => void>()
   );
@@ -647,6 +647,7 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
             evt.preventDefault();
             for (const handleExaminer of handleExaminers) {
               handleExaminer();
+              break; // They are functionally the same, trigger either one.
             }
           }
           if (evt.key === 'Escape') {

--- a/liwords-ui/src/store/store.tsx
+++ b/liwords-ui/src/store/store.tsx
@@ -429,7 +429,7 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
   const numberOfTurns = gameContext.turns.length;
   const [isExamining, setIsExamining] = useState(false);
   const [examinedTurn, setExaminedTurn] = useState(Infinity);
-  const handleExamineStart = useCallback(() => {
+  const handleExamineStartUnconditionally = useCallback(() => {
     setIsExamining(true);
   }, []);
   const handleExamineEnd = useCallback(() => {
@@ -555,6 +555,10 @@ const ExaminableStore = ({ children }: { children: React.ReactNode }) => {
     };
     return ret;
   }, [isExamining, examinedTurn, gameContext]);
+  const handleExamineStart =
+    examinableGameContext.players.length > 0
+      ? handleExamineStartUnconditionally
+      : handleExamineEnd;
 
   const isShowingLatest = !isExamining || examinedTurn >= numberOfTurns;
   const examinableGameContextStore = useMemo(() => {


### PR DESCRIPTION
- make Examine button no-op if game hasn't loaded (otherwise the light bulb will crash the page)
- don't show game end controls if opponent isn't ready (otherwise without above patch it's possible to enter and keep examine mode throughout the game while playing on another tab)
- (unrelated) examine shortcut should run one handler, not both the tablet and desktop handlers
- disable some buttons, particularly Options, if game hasn't started (otherwise Resign would register a full timeout to a random opponent, likely dependent on `secondWentFirst`, and the UI doesn't handle this)