### PR TITLE
fix personal info form resetting when receiving presence entry

### DIFF
--- a/liwords-ui/src/App.tsx
+++ b/liwords-ui/src/App.tsx
@@ -277,10 +277,7 @@ const App = React.memo(() => {
         <Route path="/profile/:username">
           <UserProfile />
         </Route>
-        <Route path="/settings/:section">
-          <Settings />
-        </Route>
-        <Route path="/settings">
+        <Route path="/settings/:section?">
           <Settings />
         </Route>
         <Route path="/tile_images">

--- a/liwords-ui/src/settings/personal_info.tsx
+++ b/liwords-ui/src/settings/personal_info.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import {
   Alert,
   Button,
@@ -23,7 +23,7 @@ import { countryArray } from './country_map';
 import { MarkdownTips } from './markdown_tips';
 import { AvatarCropper } from './avatar_cropper';
 
-type PersonalInfo = {
+export type PersonalInfo = {
   birthDate: string;
   email: string;
   firstName: string;
@@ -181,8 +181,6 @@ export const PersonalInfo = React.memo((props: Props) => {
   );
 
   const [form] = Form.useForm();
-
-  useEffect(() => form.resetFields(), [props.personalInfo, form]);
 
   const layout = {
     labelCol: {

--- a/liwords-ui/src/settings/settings.tsx
+++ b/liwords-ui/src/settings/settings.tsx
@@ -88,12 +88,9 @@ export const Settings = React.memo((props: Props) => {
   const [player, setPlayer] = useState<Partial<PlayerMetadata> | undefined>(
     undefined
   );
-  const [birthDate, setBirthDate] = useState('');
-  const [firstName, setFirstName] = useState('');
-  const [lastName, setLastName] = useState('');
-  const [countryCode, setCountryCode] = useState('');
-  const [email, setEmail] = useState('');
-  const [about, setAbout] = useState('');
+  const [personalInfo, setPersonalInfo] = useState<PersonalInfo | undefined>(
+    undefined
+  );
   const [showCloseAccount, setShowCloseAccount] = useState(false);
   const [showClosedAccount, setShowClosedAccount] = useState(false);
   const [accountClosureError, setAccountClosureError] = useState('');
@@ -129,12 +126,14 @@ export const Settings = React.memo((props: Props) => {
           full_name: resp.data.full_name,
           user_id: userID, // for name-based avatar initial to work
         });
-        setBirthDate(resp.data.birth_date);
-        setFirstName(resp.data.first_name);
-        setLastName(resp.data.last_name);
-        setCountryCode(resp.data.country_code);
-        setEmail(resp.data.email);
-        setAbout(resp.data.about);
+        setPersonalInfo({
+          birthDate: resp.data.birth_date,
+          email: resp.data.email,
+          firstName: resp.data.first_name,
+          lastName: resp.data.last_name,
+          countryCode: resp.data.country_code,
+          about: resp.data.about,
+        });
       })
       .catch(errorCatcher);
   }, [viewer, loggedIn, category, userID]);
@@ -264,21 +263,14 @@ export const Settings = React.memo((props: Props) => {
                 />
               ) : showClosedAccount ? (
                 <ClosedAccount />
-              ) : (
+              ) : personalInfo ? (
                 <PersonalInfo
                   player={player}
-                  personalInfo={{
-                    birthDate: birthDate,
-                    email: email,
-                    firstName: firstName,
-                    lastName: lastName,
-                    countryCode: countryCode,
-                    about: about,
-                  }}
+                  personalInfo={personalInfo}
                   updatedAvatar={updatedAvatar}
                   startClosingAccount={startClosingAccount}
                 />
-              )
+              ) : null
             ) : null}
             {category === Category.ChangePassword ? <ChangePassword /> : null}
             {category === Category.Preferences ? <Preferences /> : null}


### PR DESCRIPTION
#480 called `form.resetFields()` [here](https://github.com/domino14/liwords/pull/480/files#diff-9177a8e2af0736be4317bcd437ee0d0778f18bf9fa336b3888d1538cf5a8faf2R168) when there's any new `personalInfo`.

That happened on every rerender of `Settings`, because `personalInfo` is passed as a newly constructed object [here](https://github.com/domino14/liwords/pull/480/files#diff-c894645a408dc157ad716a5441d3e6d6c68be6f087f6209eeec2fb9ae51d0aebR223-R229).

Since #584, `App` has been rerendering on presence entry changes. So when a friend logs in or out while editing bio with no markdown preview, the whole form resets.

Since #601, presence entries have also included game presences, be it playing or observing.

Because HastyBot happens to be one of my few friends, it was practically impossible to edit my bio.

This PR removes `resetFields()`.