### PR TITLE
fix examiner repeated refocus

### DIFF
--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -35,8 +35,9 @@ const ExamineGameControls = React.memo((props: { lexicon: string }) => {
     setPlacedTilesTempScore(undefined);
     setPlacedTiles(new Set<EphemeralTile>());
   }, [examinedTurn, setPlacedTiles, setPlacedTilesTempScore]);
-  const initiallyFocusHere = useCallback((elt) => {
-    elt?.focus();
+  const initialFocus = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    initialFocus.current!.focus();
   }, []);
   const numberOfTurns = gameContext.turns.length;
   return (
@@ -70,7 +71,7 @@ const ExamineGameControls = React.memo((props: { lexicon: string }) => {
         onClick={handleExamineLast}
         disabled={examinedTurn >= numberOfTurns}
       />
-      <Button onClick={handleExamineEnd} ref={initiallyFocusHere}>
+      <Button onClick={handleExamineEnd} ref={initialFocus}>
         Done
       </Button>
     </div>


### PR DESCRIPTION
fix #777
- it happened regardless of turn being examined (doesn't have to be the last turn)
- it turned out #410 didn't do it correctly