### PR TITLE
remove link in sign up page

### DIFF
--- a/liwords-ui/src/lobby/register.tsx
+++ b/liwords-ui/src/lobby/register.tsx
@@ -412,12 +412,7 @@ export const Register = () => {
           <p>
             Welcome to Woogles, the online home for word games! If you want to
             be the champion of crossword game, or maybe just want to find a
-            friendly match you’re in the right place. By the way, signing up
-            means you agree to our{' '}
-            <Link target="_blank" to="/about">
-              Privacy Policy
-            </Link>
-            .
+            friendly match you’re in the right place.
           </p>
           <p>- Woogles and team</p>
           <Form layout="inline" name="register" onFinish={onFinish} form={form}>


### PR DESCRIPTION
just remove the link, from

<img width="653" alt="Screenshot 2021-07-31 at 11 32 37" src="https://user-images.githubusercontent.com/4179698/127727514-a0ccab5e-571d-4a06-b41f-042e2f4f69d5.png">

to

<img width="627" alt="Screenshot 2021-07-31 at 11 32 42" src="https://user-images.githubusercontent.com/4179698/127727536-f1497b68-462d-48e9-bb68-25d192b7210e.png">

because anyway the terms page is already linked from the checkbox
