### PR TITLE
fix disabled examiner shortcuts

### DIFF
--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -28,6 +28,7 @@ const ExamineGameControls = React.memo((props: { lexicon: string }) => {
     handleExaminePrev,
     handleExamineNext,
     handleExamineLast,
+    doneButtonRef,
   } = useExamineStoreContext();
   const { gameContext } = useGameContextStoreContext();
   const { setPlacedTiles, setPlacedTilesTempScore } = useTentativeTileContext();
@@ -35,10 +36,9 @@ const ExamineGameControls = React.memo((props: { lexicon: string }) => {
     setPlacedTilesTempScore(undefined);
     setPlacedTiles(new Set<EphemeralTile>());
   }, [examinedTurn, setPlacedTiles, setPlacedTilesTempScore]);
-  const initialFocus = useRef<HTMLElement | null>(null);
   useEffect(() => {
-    initialFocus.current!.focus();
-  }, []);
+    doneButtonRef.current!.focus();
+  }, [doneButtonRef]);
   const numberOfTurns = gameContext.turns.length;
   return (
     <div className="game-controls">
@@ -71,7 +71,7 @@ const ExamineGameControls = React.memo((props: { lexicon: string }) => {
         onClick={handleExamineLast}
         disabled={examinedTurn >= numberOfTurns}
       />
-      <Button onClick={handleExamineEnd} ref={initialFocus}>
+      <Button onClick={handleExamineEnd} ref={doneButtonRef}>
         Done
       </Button>
     </div>


### PR DESCRIPTION
clicking the ">>" button navigates to the last move, where the button gets disabled. disabling the button unintentionally disabled first/prev [shortcuts](https://github.com/domino14/liwords/wiki/Secret-features#examiner-shortcuts) (`<`/`,`).

in chrome the button loses focus completely. in firefox it simply doesn't respond to the shortcuts. in both cases the fix is to focus on the Done button.