### PR TITLE
fix analyzer rack leave ordering

### DIFF
--- a/liwords-ui/src/gameroom/analyzer.tsx
+++ b/liwords-ui/src/gameroom/analyzer.tsx
@@ -244,7 +244,7 @@ const parseExaminableGameContext = (
   const labelToNum = labelToNumFor(letterDistribution);
   const numToLabel = numToLabelFor(letterDistribution);
 
-  const rackStr = players[onturn].currentRack;
+  const rackStr = sortTiles(players[onturn].currentRack);
   const rackNum = Array.from(rackStr, labelToNum);
 
   let effectiveLexicon = lexicon;


### PR DESCRIPTION
#678 put the gaps according to a different sorting order, resulting in inconsistency when picking an examiner move that keeps the blank and some other tiles on the rack. this should make it more consistent