### PR TITLE
add auto shuffle option

### DIFF
--- a/liwords-ui/src/gameroom/board_panel.tsx
+++ b/liwords-ui/src/gameroom/board_panel.tsx
@@ -57,6 +57,7 @@ import {
   useTentativeTileContext,
   useTimerStoreContext,
 } from '../store/store';
+import { sharedEnableAutoShuffle } from '../store/constants';
 import { BlankSelector } from './blank_selector';
 import { GameEndMessage } from './game_end_message';
 import { PlayerMetadata, GCGResponse, ChallengeRule } from './game_info';
@@ -567,7 +568,9 @@ export const BoardPanel = React.memo((props: Props) => {
         setPlacedTilesTempScore(bak.placedTilesTempScore);
         setArrowProperties(bak.arrowProperties);
       } else {
-        setDisplayedRack(props.currentRack);
+        let rack = props.currentRack;
+        if (sharedEnableAutoShuffle) rack = shuffleString(rack);
+        setDisplayedRack(rack);
         setPlacedTiles(new Set<EphemeralTile>());
         setPlacedTilesTempScore(0);
         setArrowProperties({

--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -1,7 +1,12 @@
 import React, { useCallback } from 'react';
 import { useMountedState } from '../utils/mounted';
 import { Col, Row, Select, Switch } from 'antd';
-import { preferredSortOrder, setPreferredSortOrder } from '../store/constants';
+import {
+  preferredSortOrder,
+  setPreferredSortOrder,
+  setSharedEnableAutoShuffle,
+  sharedEnableAutoShuffle,
+} from '../store/constants';
 import '../gameroom/scss/gameroom.scss';
 import { TileLetter, PointValue } from '../gameroom/tile';
 import { BoardPreview } from './board_preview';
@@ -157,6 +162,10 @@ export const Preferences = React.memo((props: Props) => {
     setDarkMode((x) => !x);
   }, []);
 
+  const toggleAutoShuffle = useCallback(() => {
+    setSharedEnableAutoShuffle(!sharedEnableAutoShuffle);
+  }, []);
+
   const handleUserTileChange = useCallback((tileStyle: string) => {
     const classes = document?.body?.className
       .split(' ')
@@ -223,6 +232,19 @@ export const Preferences = React.memo((props: Props) => {
               <Select.Option value={tileOrder}>Custom</Select.Option>
             )}
           </Select>
+        </Col>
+      </Row>
+      <div className="toggle-section">
+        <div className="title">Random tile order</div>
+        <div>Automatically shuffle tiles at every turn</div>
+        <Switch
+          defaultChecked={sharedEnableAutoShuffle}
+          onChange={toggleAutoShuffle}
+          className="auto-shuffle-toggle"
+        />
+      </div>
+      <Row>
+        <Col span={12}>
           <div className="tile-order">Tile style</div>
           <div className="tile-selection">
             <Select

--- a/liwords-ui/src/settings/preferences.tsx
+++ b/liwords-ui/src/settings/preferences.tsx
@@ -212,11 +212,13 @@ export const Preferences = React.memo((props: Props) => {
       console.error(e);
     }
   }, []);
+  const localEnableAutoShuffle = sharedEnableAutoShuffle;
   const tileOrderValue = React.useMemo(
-    () => makeTileOrderValue(tileOrder, sharedEnableAutoShuffle),
-    [tileOrder, sharedEnableAutoShuffle]
+    () => makeTileOrderValue(tileOrder, localEnableAutoShuffle),
+    [tileOrder, localEnableAutoShuffle]
   );
   const tileOrderOptions = React.useMemo(() => {
+    void reevaluateTileOrderOptions;
     const ret: Array<{ name: React.ReactElement; value: string }> = [];
     const pushTileOrder = (
       name: string,
@@ -226,7 +228,7 @@ export const Preferences = React.memo((props: Props) => {
       // Design only wants "Random" for "Alphabetical".
       if (
         !(
-          (tileOrder === value && autoShuffle === sharedEnableAutoShuffle) ||
+          (tileOrder === value && autoShuffle === localEnableAutoShuffle) ||
           name === 'Alphabetical' ||
           !autoShuffle
         )
@@ -235,7 +237,7 @@ export const Preferences = React.memo((props: Props) => {
       }
       let nameText = name;
       let hoverHelp = null;
-      if (autoShuffle !== sharedEnableAutoShuffle) {
+      if (autoShuffle !== localEnableAutoShuffle) {
         hoverHelp = `(turn ${autoShuffle ? 'on' : 'off'} auto-shuffle)`;
       }
       if (name === 'Alphabetical' && autoShuffle) {
@@ -274,7 +276,7 @@ export const Preferences = React.memo((props: Props) => {
       addTileOrder({ name: 'Custom', value: tileOrder });
     }
     return ret;
-  }, [reevaluateTileOrderOptions, tileOrder, sharedEnableAutoShuffle]);
+  }, [reevaluateTileOrderOptions, tileOrder, localEnableAutoShuffle]);
 
   return (
     <div className="preferences">

--- a/liwords-ui/src/store/constants.ts
+++ b/liwords-ui/src/store/constants.ts
@@ -166,6 +166,18 @@ export const challRuleToStr = (n: number): string => {
   return 'Unsupported';
 };
 
+export let sharedEnableAutoShuffle =
+  localStorage.getItem('enableAutoShuffle') === 'true';
+
+export const setSharedEnableAutoShuffle = (value: boolean) => {
+  if (value) {
+    localStorage.setItem('enableAutoShuffle', 'true');
+  } else {
+    localStorage.removeItem('enableAutoShuffle');
+  }
+  sharedEnableAutoShuffle = value;
+};
+
 // To expose this and make it more ergonomic to reorder without refreshing.
 export let preferredSortOrder = localStorage.getItem('tileOrder');
 


### PR DESCRIPTION
for #787 - please adjust styling etc.

the "default tile order" preference must be deterministic (it's used for "reset rack", scorecard, analyzer, notepad's plus button, and maybe others). so instead of adding a "random" option there, this PR adds a new option to automatically shuffle the rack at (the start of) every turn. "reset rack" will still re-sort (alphabetize or whatever the preferred order is).

because we keep a backup of one turn (to reinstate premove on successful challenge, see #759), even if toggling this option directly from the board were possible, it would only take effect two turns later. conversely, because we only keep a backup of one turn, with auto shuffle enabled, navigating from turn A to turn B to turn C and back to turn A will not recover rack A's ordering, it will be reshuffled anew.

<img width="536" alt="Screenshot 2021-08-09 at 18 50 12" src="https://user-images.githubusercontent.com/4179698/128695629-086ffd27-ac3b-4cd4-ba14-cf64369e71d3.png">
