### PR TITLE
Mobile modals

### DIFF
--- a/liwords-ui/src/base.scss
+++ b/liwords-ui/src/base.scss
@@ -604,6 +604,38 @@ ul {
     .ant-modal-footer {
       border: 0;
     }
+    @media (max-width: $screen-mobile-min + 1) {
+      .ant-modal-mask {
+        @include colorModed() {
+          background: m($background);
+        }
+      }
+      .ant-modal {
+        margin: unset;
+        max-width: unset;
+        top: 0;
+        .ant-modal-content {
+          height: 100vh;
+          width: 100vw;
+          box-shadow: none;
+          padding-bottom: 48px;
+        }
+        .ant-modal-header {
+          border-radius: 0;
+        }
+        .ant-modal-footer {
+          position: fixed;
+          bottom: 0;
+          width: 100vw;
+          flex-direction: column;
+          padding: 12px;
+          button, button.ant-btn {
+            width: 100%;
+            margin: 6px 0;
+          }
+        }
+      }
+    }
   }
 }
 @mixin button {

--- a/liwords-ui/src/base.scss
+++ b/liwords-ui/src/base.scss
@@ -623,9 +623,10 @@ ul {
         .ant-modal-header {
           border-radius: 0;
         }
-        .ant-modal-footer {
+        .ant-modal-footer, .ant-modal-confirm-btns {
           position: fixed;
           bottom: 0;
+          left: 0;
           width: 100vw;
           flex-direction: column;
           padding: 12px;

--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -293,7 +293,7 @@ const GameControls = React.memo((props: Props) => {
               // XXX: what if it's unrated?
               content: (
                 <p className="readable-text-color">
-                  Your rating will be maximally affected.
+                  Your rating may be affected.
                 </p>
               ),
               onOk() {

--- a/liwords-ui/src/gameroom/scorecard.tsx
+++ b/liwords-ui/src/gameroom/scorecard.tsx
@@ -19,7 +19,7 @@ import { Notepad } from './notepad';
 import { sortTiles } from '../store/constants';
 import { getVW, isTablet } from '../utils/cwgame/common';
 import { Analyzer } from './analyzer';
-import { StarFilled } from '@ant-design/icons';
+import { HeartFilled } from '@ant-design/icons';
 const screenSizes = require('../base.scss');
 
 type Props = {
@@ -212,7 +212,7 @@ const ScorecardTurn = (props: turnProps) => {
         <div className="play">
           <p className="main-word">
             {memoizedTurn.play}
-            {memoizedTurn.isBingo && <StarFilled />}
+            {memoizedTurn.isBingo && <HeartFilled />}
           </p>
           <p>{memoizedTurn.rack}</p>
         </div>

--- a/liwords-ui/src/gameroom/scss/gameroom.scss
+++ b/liwords-ui/src/gameroom/scss/gameroom.scss
@@ -1182,9 +1182,10 @@ p.rune {
     &.bingo {
       .anticon {
         position: relative;
-        top: -2px;
-        font-size: 8px;
         margin: 0 6px;
+        @include colorModed() {
+          color: m($timer-out-dark);
+        }
       }
     }
     &:hover {

--- a/liwords-ui/src/lobby/lobby.scss
+++ b/liwords-ui/src/lobby/lobby.scss
@@ -55,6 +55,9 @@
       padding-top: 0px;
     }
   }
+  @media (max-width: $screen-tablet-min + 1) {
+    order: 3;
+  }
 }
 
 .announcements {

--- a/liwords-ui/src/lobby/seek_form.tsx
+++ b/liwords-ui/src/lobby/seek_form.tsx
@@ -424,7 +424,7 @@ export const SeekForm = (props: Props) => {
 
       {props.vsBot && (
         <Form.Item label="Select bot level" name="botType">
-          <Select>
+          <Select listHeight={500}>
             {[
               BotTypesEnum.MASTER,
               BotTypesEnum.EXPERT,


### PR DESCRIPTION
Make modals full screen on mobile, and make the bot selection dropdown longer. Bonus: less alarming resign message and  make the bingo marker a blue heart instead of a confusing star

![image](https://user-images.githubusercontent.com/6097979/132956932-fbfed624-3206-41ef-a529-ff3bcaf5d508.png)
