### PR TITLE
fix shown rating names

### DIFF
--- a/liwords-ui/src/profile/profile.tsx
+++ b/liwords-ui/src/profile/profile.tsx
@@ -17,7 +17,7 @@ import { UsernameWithContext } from '../shared/usernameWithContext';
 import { moderateUser } from '../mod/moderate';
 import { DisplayFlag } from '../shared/display_flag';
 import { VariantIcon } from '../shared/variant_icons';
-import { AllLexica } from '../shared/lexica';
+import { lexiconCodeToProfileRatingName } from '../shared/lexica';
 
 type ProfileResponse = {
   birth_date: string;
@@ -84,7 +84,7 @@ type StatsProps = {
 const variantToName = (variant: string) => {
   const arr = variant.split('.');
   let lex = arr[0];
-  lex = AllLexica[lex]?.ratingName || arr[0];
+  lex = lexiconCodeToProfileRatingName(lex);
 
   const timectrl = {
     ultrablitz: 'Ultra-Blitz!',

--- a/liwords-ui/src/shared/lexica.ts
+++ b/liwords-ui/src/shared/lexica.ts
@@ -2,10 +2,40 @@
  * @fileoverview A mapping between lexicon codes and user-visible lexicon names.
  */
 
+// internal rating name is saved in db (select ratings->'Data' from profiles).
+// it follows pkg/entity/ratings.go ToVariantKey.
+// XXX: foreign ratings aren't grouped by family.
+const lexiconCodeToInternalRatingName = (code: string) => {
+  if (code.startsWith('NWL')) return 'NWL18';
+  if (code.startsWith('CSW')) return 'CSW19';
+  if (code.startsWith('ECWL')) return 'ECWL';
+  return code;
+};
+
+// profile rating name is the name that shows up in your profile ratings.
+const InternalRatingNameToProfileRatingName: {
+  [code: string]: string;
+} = {
+  NWL18: 'NWL',
+  NSWL20: 'NSWL',
+  CSW19: 'CSW',
+  ECWL: 'CEL',
+  RD28: 'Deutsch',
+  NSF21: 'Norsk',
+  FRA20: 'Français',
+};
+
+export const lexiconCodeToProfileRatingName = (code: string) => {
+  const internalRatingName = lexiconCodeToInternalRatingName(code);
+  return (
+    InternalRatingNameToProfileRatingName[internalRatingName] ??
+    internalRatingName
+  );
+};
+
 type Lexicon = {
   code: string;
   shortDescription: string;
-  ratingName: string; // the name that shows up in your profile ratings
   matchName: string; // the name that shows up in a match/seek/watch
   longDescription?: string;
   flagCode?: string;
@@ -15,7 +45,6 @@ export const AllLexica: { [code: string]: Lexicon } = {
   NWL20: {
     code: 'NWL20',
     shortDescription: 'NWL 20 (North American English)',
-    ratingName: 'NWL',
     matchName: 'NWL20',
     longDescription:
       'NASPA Word List, 2020 Edition (NWL20), © 2020 North American Word Game Players Association. All rights reserved.',
@@ -25,7 +54,6 @@ export const AllLexica: { [code: string]: Lexicon } = {
   NSWL20: {
     code: 'NSWL20',
     shortDescription: 'NSWL 20 (NASPA School Word List)',
-    ratingName: 'NSWL',
     matchName: 'NSWL20',
     longDescription:
       'NASPA School Word List 2020 Edition (NSWL20), © 2020 North American Word Game Players Association. All rights reserved.',
@@ -33,7 +61,6 @@ export const AllLexica: { [code: string]: Lexicon } = {
   CSW21: {
     code: 'CSW21',
     shortDescription: 'CSW 21 (World English)',
-    ratingName: 'CSW',
     matchName: 'CSW21',
     longDescription:
       'Published under license with Collins, an imprint of HarperCollins Publishers Limited',
@@ -41,7 +68,6 @@ export const AllLexica: { [code: string]: Lexicon } = {
   ECWL: {
     code: 'ECWL',
     shortDescription: 'CEL (Common English Lexicon)',
-    ratingName: 'CEL',
     matchName: 'CEL',
     longDescription:
       'Common English Lexicon, Copyright (c) 2021 Fj00. Used with permission',
@@ -49,7 +75,6 @@ export const AllLexica: { [code: string]: Lexicon } = {
   RD28: {
     code: 'RD28',
     shortDescription: 'Deutsch (German)',
-    ratingName: 'Deutsch',
     matchName: 'Deutsch',
     longDescription:
       'The “Scrabble®-Turnierliste” used as the German Lexicon is subject to copyright and related rights of Scrabble® Deutschland e.V. With the friendly assistance of Gero Illings SuperDic.',
@@ -58,7 +83,6 @@ export const AllLexica: { [code: string]: Lexicon } = {
   NSF21: {
     code: 'NSF21',
     shortDescription: 'Norsk (Norwegian)',
-    ratingName: 'Norsk',
     matchName: 'Norsk',
     longDescription:
       'The NSF word list is provided by the language committee of the Norwegian Scrabble Player Association. Used with permission.',
@@ -67,14 +91,12 @@ export const AllLexica: { [code: string]: Lexicon } = {
   FRA20: {
     code: 'FRA20',
     shortDescription: 'Français (French)',
-    ratingName: 'Français',
     matchName: 'Français',
     flagCode: 'fr',
   },
   CSW19X: {
     code: 'CSW19X',
     shortDescription: 'CSW19X (School Expurgated)',
-    ratingName: 'CSW',
     matchName: 'CSW19X',
   },
 };


### PR DESCRIPTION
fix #895 

context:
- 0794b4e8ae59cc4bbd8c3012883fc7e4dc783353
- f2df947d23ca74773f34c57277054fcd9202d514