### PR TITLE
reset store without reconnecting socket

### DIFF
--- a/liwords-ui/src/lobby/login.tsx
+++ b/liwords-ui/src/lobby/login.tsx
@@ -11,7 +11,7 @@ import { toAPIUrl } from '../api/api';
 
 export const Login = React.memo(() => {
   const { useState } = useMountedState();
-  const { resetStore } = useResetStoreContext();
+  const { resetLoginStateStore } = useResetStoreContext();
 
   const [err, setErr] = useState('');
   const [loggedIn, setLoggedIn] = useState(false);
@@ -42,9 +42,9 @@ export const Login = React.memo(() => {
 
   React.useEffect(() => {
     if (loggedIn) {
-      resetStore();
+      resetLoginStateStore();
     }
-  }, [loggedIn, resetStore]);
+  }, [loggedIn, resetLoginStateStore]);
 
   return (
     <div className="account">

--- a/liwords-ui/src/settings/settings.tsx
+++ b/liwords-ui/src/settings/settings.tsx
@@ -80,7 +80,7 @@ export const Settings = React.memo((props: Props) => {
   const { loginState } = useLoginStateStoreContext();
   const { userID, username: viewer, loggedIn } = loginState;
   const { useState } = useMountedState();
-  const { resetStore } = useResetStoreContext();
+  const { resetLoginStateStore } = useResetStoreContext();
   const { section } = useParams();
   const [category, setCategory] = useState(
     getInitialCategory(section, loggedIn)
@@ -170,13 +170,13 @@ export const Settings = React.memo((props: Props) => {
           message: 'Success',
           description: 'You have been logged out.',
         });
-        resetStore();
+        resetLoginStateStore();
         history.push('/');
       })
       .catch((e) => {
         console.log(e);
       });
-  }, [history, resetStore]);
+  }, [history, resetLoginStateStore]);
 
   const updatedAvatar = useCallback(
     (avatarUrl: string) => {

--- a/liwords-ui/src/store/login_state.ts
+++ b/liwords-ui/src/store/login_state.ts
@@ -1,21 +1,15 @@
 import { Action, ActionType } from '../actions/actions';
 
-export type LoginState = {
-  username: string;
-  userID: string;
-  loggedIn: boolean;
-  connID: string;
-  connectedToSocket: boolean;
-  path: string;
-  perms: Array<string>;
-};
-
 export type AuthInfo = {
   username: string;
   userID: string;
   loggedIn: boolean;
   connID: string;
   perms: Array<string>;
+};
+
+export type LoginState = AuthInfo & {
+  connectedToSocket: boolean;
 };
 
 export function LoginStateReducer(

--- a/liwords-ui/src/store/socket_handlers.ts
+++ b/liwords-ui/src/store/socket_handlers.ts
@@ -155,6 +155,8 @@ export const ReverseMessageType = (() => {
   return ret;
 })();
 
+// This needs to have access to Rest Of Store.
+// Therefore it cannot be used directly from LiwordsSocket.
 export const useOnSocketMsg = () => {
   const { challengeResultEvent } = useChallengeResultEventStoreContext();
   const { addChat, deleteChat } = useChatStoreContext();

--- a/liwords-ui/src/topbar/topbar.tsx
+++ b/liwords-ui/src/topbar/topbar.tsx
@@ -81,7 +81,7 @@ export const TopBar = React.memo((props: Props) => {
 
   const { currentLagMs } = useLagStoreContext();
   const { loginState } = useLoginStateStoreContext();
-  const { resetStore } = useResetStoreContext();
+  const { resetLoginStateStore } = useResetStoreContext();
   const { tournamentContext } = useTournamentStoreContext();
   const { username, loggedIn, connectedToSocket } = loginState;
   const [loginModalVisible, setLoginModalVisible] = useState(false);
@@ -97,7 +97,7 @@ export const TopBar = React.memo((props: Props) => {
           message: 'Success',
           description: 'You have been logged out.',
         });
-        resetStore();
+        resetLoginStateStore();
       })
       .catch((e) => {
         console.log(e);

--- a/liwords-ui/src/tournament/room.tsx
+++ b/liwords-ui/src/tournament/room.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import {
   useLoginStateStoreContext,
@@ -35,7 +36,8 @@ export const TournamentRoom = (props: Props) => {
   const { competitorState: competitorContext } = tournamentContext;
   const { isRegistered } = competitorContext;
   const { sendSocketMsg } = props;
-  const { path } = loginState;
+  const location = useLocation();
+  const path = location.pathname;
   const [badTournament, setBadTournament] = useState(false);
   const [selectedGameTab, setSelectedGameTab] = useState('GAMES');
 


### PR DESCRIPTION
partial attempt at #877.

`liwords-socket` needs the path to know which realms to subscribe to. if the path changes, the socket must be killed and reconnected.

on closer inspection, it seems only paths starting with `/game/`, ` /tournament/`, or `/club/` need to be preserved.

this PR
- moves `LiwordsSocket` to between `LoginStateStore` and `RestOfStore`.
- changes the reset whole store on path change to reset only `RestOfStore`, so that in itself this does not cause socket reconnection.
- removes `path` from `LoginStateStore`. it's only used in `TournamentRoom` and is currently always equal to the path returned by `react-router-dom` anyway. also removes `isChild`, which is unused. (there is a [no-op cast in `store/login_state.ts` that seems to not prevent injection of such additional keys during the object spread](https://github.com/domino14/liwords/blob/212d247da63d22a98cee9ae9918242cbb7a375dc/liwords-ui/src/store/login_state.ts#L27-L31).)
- canonicalizes, for the purpose of socket realm subscription, all paths not starting with `/game/`, ` /tournament/`, or `/club/` to `/`. so, there's no reconnection when people go from `/` to `/profile` to `/settings` to `/team` or something like that. (of course it's not very useful if the main load is from rematch redirects.)
- late-binds the socket handler to accommodate the above change. while the socket itself only depends on the login state and canonicalized path, the handler called when a socket message arrives processes that message on the rest of store.
- does nothing about auto socket reconnection, it seems there's already some logic there.

expect even more bugs. test thoroughly and be ready to revert.

obviously, this PR introduces a new bug: socket messages received by the old handler will be processed by the old rest of store, and socket messages received by the new handler will be processed by the new rest of store after reset. (there's also a brief period of time when neither handler is installed, during which received messages are lost permanently.) as long as "reset rest of store" is still a thing, this bug cannot be fixed.