### PR TITLE
Replace Muli with Mulish in styles

### DIFF
--- a/liwords-ui/src/admin/admin.scss
+++ b/liwords-ui/src/admin/admin.scss
@@ -2,7 +2,7 @@
 
 .tourney-editor {
   h3 {
-    font-family: muli, sans-serif;
+    font-family: 'Mulish', sans-serif;
     font-size: 15px;
     font-width: bold;
     margin: 96px 24px 18px;

--- a/liwords-ui/src/base.scss
+++ b/liwords-ui/src/base.scss
@@ -34,7 +34,7 @@ $screen-min-height-desktop-min: 830px;
 $screen-min-height-desktop-max: 910px;
 
 $font-deco: 'Fjalla One', sans-serif;
-$font-default: 'Muli', sans-serif;
+$font-default: 'Mulish', sans-serif;
 $font-monospaced: 'Courier Prime', monospace;
 $font-tile: 'Roboto Mono', monospace;
 

--- a/liwords-ui/src/chat/chat.scss
+++ b/liwords-ui/src/chat/chat.scss
@@ -40,7 +40,7 @@ p {
   width: 15px;
   height: 15px;
   font-size: 10px;
-  font-family: 'Muli';
+  font-family: 'Mulish';
   line-height: 0;
   text-align: center;
   padding: 1px 0 0 2px;

--- a/liwords-ui/src/profile/profile.scss
+++ b/liwords-ui/src/profile/profile.scss
@@ -20,7 +20,7 @@
     width: auto;
     display: flex;
     justify-content: space-between;
-    font-family: Muli, sans-serif;
+    font-family: 'Mulish', sans-serif;
     letter-spacing: 0;
     font-weight: bold;
     span.user {


### PR DESCRIPTION
I noticed that Mulish is now being loaded instead of Muli, but the stylesheets haven't been updated yet. Sorry if this is intentional, but there were some complaints on the help chat and Discord about it.