### PR TITLE
Load all the sizes

### DIFF
--- a/liwords-ui/public/index.html
+++ b/liwords-ui/public/index.html
@@ -45,9 +45,9 @@
       rel="stylesheet"
     />
     <link
-      href="https://fonts.googleapis.com/css2?family=Mulish&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Mulish:wght@400;500;700;900&display=swap"
       rel="stylesheet"
-    />
+    >
     <link
       href="https://fonts.googleapis.com/css2?family=Fjalla+One&display=swap"
       rel="stylesheet"


### PR DESCRIPTION
Actually correct this time. We have to tell Google we want the new weights, otherwise we get the old ones only, despite calling the nondeprecated version.

![](https://files.slack.com/files-pri/T011MHUEUBY-F0330EZP30S/image.png)
