### PR TITLE
fix requesting of mass amounts of data at the start of each tournament game

### DIFF
--- a/pkg/gameplay/game.go
+++ b/pkg/gameplay/game.go
@@ -241,16 +241,18 @@ func StartGame(ctx context.Context, gameStore GameStore, userStore user.Store, e
 
 	// If the previous game was a rematch, notify
 	// the viewers that this game has started.
-	rematchStreak, err := gameStore.GetRematchStreak(ctx, entGame.Quickdata.OriginalRequestId)
-	if err != nil {
-		return err
-	}
-	if len(rematchStreak.Streak) > 0 {
-		previousGameID := rematchStreak.Streak[0].GameId
-		evt := &pb.RematchStartedEvent{RematchGameId: entGame.GameID()}
-		wrappedRematch := entity.WrapEvent(evt, pb.MessageType_REMATCH_STARTED)
-		wrappedRematch.AddAudience(entity.AudGameTV, previousGameID)
-		entGame.SendChange(wrappedRematch)
+	if entGame.Quickdata.OriginalRequestId != "" {
+		rematchStreak, err := gameStore.GetRematchStreak(ctx, entGame.Quickdata.OriginalRequestId)
+		if err != nil {
+			return err
+		}
+		if len(rematchStreak.Streak) > 0 {
+			previousGameID := rematchStreak.Streak[0].GameId
+			evt := &pb.RematchStartedEvent{RematchGameId: entGame.GameID()}
+			wrappedRematch := entity.WrapEvent(evt, pb.MessageType_REMATCH_STARTED)
+			wrappedRematch.AddAudience(entity.AudGameTV, previousGameID)
+			entGame.SendChange(wrappedRematch)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
we were querying every game with a blank original request id and processing every single one of them at the beginning of every tournament game. Fix this. Also optimize rematch streak a bit.

Closes #837