### PR TITLE
Allow editing of finished tournaments

### DIFF
--- a/pkg/tournament/service.go
+++ b/pkg/tournament/service.go
@@ -500,10 +500,6 @@ func authenticateDirector(ctx context.Context, ts *TournamentService, id string,
 	if !authorized {
 		return twirp.NewError(twirp.Unauthenticated, "this user is not an authorized director for this event")
 	}
-	if t.IsFinished {
-		return twirp.NewError(twirp.InvalidArgument, "this tournament is finished and cannot be modified")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
If we want to disallow this again, it doesn't make sense to put the check in the `authenticate` call anyway.