### PR TITLE
puzzle rack adjustments

### DIFF
--- a/liwords-ui/src/puzzles/puzzle.tsx
+++ b/liwords-ui/src/puzzles/puzzle.tsx
@@ -228,7 +228,10 @@ export const SinglePuzzle = (props: Props) => {
         tiles: evt.getPlayedTiles() || evt.getExchanged(),
         isExchange: evt.getType() === GameEvent.Type.EXCHANGE,
         leave: '',
-        leaveWithGaps: computeLeave(evt.getPlayedTiles(), sortedRack),
+        leaveWithGaps: computeLeave(
+          evt.getPlayedTiles() || evt.getExchanged(),
+          sortedRack
+        ),
       };
       placeMove(m);
     },

--- a/liwords-ui/src/puzzles/puzzle.tsx
+++ b/liwords-ui/src/puzzles/puzzle.tsx
@@ -542,7 +542,7 @@ export const SinglePuzzle = (props: Props) => {
 
   const responseModalWrong = useMemo(() => {
     const reset = () => {
-      setDisplayedRack(rack);
+      setDisplayedRack(sortedRack);
       setPlacedTiles(new Set<EphemeralTile>());
       setPlacedTilesTempScore(undefined);
       setPhoniesPlayed([]);
@@ -594,7 +594,7 @@ export const SinglePuzzle = (props: Props) => {
     showResponseModalWrong,
     phoniesPlayed,
     puzzleInfo,
-    rack,
+    sortedRack,
     setDisplayedRack,
     setPlacedTiles,
     setPlacedTilesTempScore,


### PR DESCRIPTION
- found the previous code's `computeLeave("....L.ND", "?CDLNPR")` returned `"CPR"`, this was breaking https://woogles.io/puzzle/6tj8hzzPA2nQzfTuJ9sMVP (blank disappeared when showing solution)
- rewrite `computeLeave` to make it return gaps similar to analyzer
- fix wrong answer handling to reinstate `sortedRack` (which is preference-based) instead of `rack` (which seems to be unicode-sorted and puts `?` in front)
- fix `computeLeave` parameter not looking at exchanged tiles