### PR TITLE
reset filter when you creat a seek in a filtered out language

### DIFF
--- a/liwords-ui/src/actions/actions.ts
+++ b/liwords-ui/src/actions/actions.ts
@@ -13,6 +13,8 @@ export enum ActionType {
   AddActiveGames,
   RemoveActiveGame,
 
+  setLobbyFilterByLexicon,
+
   // XXX: should move somewhere else?
   UpdateProfile,
 

--- a/liwords-ui/src/lobby/active_games.tsx
+++ b/liwords-ui/src/lobby/active_games.tsx
@@ -171,7 +171,7 @@ export const ActiveGames = (props: Props) => {
           value: l,
         })
       ),
-      defaultFilteredValue: lobbyFilterByLexiconArray,
+      filteredValue: lobbyFilterByLexiconArray,
       filterMultiple: true,
       onFilter: (
         value: string | number | boolean,

--- a/liwords-ui/src/lobby/gameLists.tsx
+++ b/liwords-ui/src/lobby/gameLists.tsx
@@ -8,6 +8,7 @@ import { ActiveGames } from './active_games';
 import { SeekForm } from './seek_form';
 import { useContextMatchContext, useLobbyStoreContext } from '../store/store';
 import { ActiveGame, SoughtGame } from '../store/reducers/lobby_reducer';
+import { ActionType } from '../actions/actions';
 import './seek_form.scss';
 
 type Props = {
@@ -33,7 +34,7 @@ export const GameLists = React.memo((props: Props) => {
     setSelectedGameTab,
     onSeekSubmit,
   } = props;
-  const { lobbyContext } = useLobbyStoreContext();
+  const { lobbyContext, dispatchLobbyContext } = useLobbyStoreContext();
   const [formDisabled, setFormDisabled] = useState(false);
   const [seekModalVisible, setSeekModalVisible] = useState(false);
   const [matchModalVisible, setMatchModalVisible] = useState(false);
@@ -149,6 +150,16 @@ export const GameLists = React.memo((props: Props) => {
       </>
     );
   };
+  const resetLobbyFilter = (gameLexicon: string) => {
+    const lobbyFilter = localStorage.getItem('lobbyFilterByLexicon');
+    if (lobbyFilter && lobbyFilter !== gameLexicon) {
+      localStorage.removeItem('lobbyFilterByLexicon');
+      dispatchLobbyContext({
+        actionType: ActionType.setLobbyFilterByLexicon,
+        payload: null,
+      });
+    }
+  };
   const onFormSubmit = (sg: SoughtGame) => {
     setSeekModalVisible(false);
     setMatchModalVisible(false);
@@ -160,6 +171,7 @@ export const GameLists = React.memo((props: Props) => {
         setFormDisabled(false);
       }, 500);
     }
+    resetLobbyFilter(sg.lexicon);
   };
   const seekModal = (
     <Modal

--- a/liwords-ui/src/lobby/sought_games.tsx
+++ b/liwords-ui/src/lobby/sought_games.tsx
@@ -24,6 +24,8 @@ import { RatingBadge } from './rating_badge';
 import { VariantIcon } from '../shared/variant_icons';
 import { MatchLexiconDisplay } from '../shared/lexicon_display';
 import { ProfileUpdate } from '../gen/api/proto/ipc/users_pb';
+import { useLobbyStoreContext } from '../store/store';
+import { ActionType } from '../actions/actions';
 
 export const timeFormat = (
   initialTimeSecs: number,
@@ -82,9 +84,10 @@ type Props = {
 export const SoughtGames = (props: Props) => {
   const { useState } = useMountedState();
   const [cancelVisible, setCancelVisible] = useState(false);
-  const [lobbyFilterByLexicon, setLobbyFilterByLexicon] = useState(
-    localStorage.getItem('lobbyFilterByLexicon')
-  );
+  const {
+    lobbyContext: { lobbyFilterByLexicon },
+    dispatchLobbyContext,
+  } = useLobbyStoreContext();
   const lobbyFilterByLexiconArray = useMemo(
     () => lobbyFilterByLexicon?.match(/\S+/g) ?? [],
     [lobbyFilterByLexicon]
@@ -151,17 +154,23 @@ export const SoughtGames = (props: Props) => {
         if (filters.lexicon && filters.lexicon.length > 0) {
           const lexicon = filters.lexicon.join(' ');
           if (lexicon !== lobbyFilterByLexicon) {
-            setLobbyFilterByLexicon(lexicon);
             localStorage.setItem('lobbyFilterByLexicon', lexicon);
+            dispatchLobbyContext({
+              actionType: ActionType.setLobbyFilterByLexicon,
+              payload: lexicon,
+            });
           }
         } else {
           // filter is reset, remove lexicon
-          setLobbyFilterByLexicon(null);
           localStorage.removeItem('lobbyFilterByLexicon');
+          dispatchLobbyContext({
+            actionType: ActionType.setLobbyFilterByLexicon,
+            payload: null,
+          });
         }
       }
     },
-    [lobbyFilterByLexicon]
+    [lobbyFilterByLexicon, dispatchLobbyContext]
   );
 
   type SoughtGameTableData = {

--- a/liwords-ui/src/lobby/sought_games.tsx
+++ b/liwords-ui/src/lobby/sought_games.tsx
@@ -118,7 +118,7 @@ export const SoughtGames = (props: Props) => {
           value: l,
         })
       ),
-      defaultFilteredValue: lobbyFilterByLexiconArray,
+      filteredValue: lobbyFilterByLexiconArray,
       filterMultiple: true,
       onFilter: (
         value: string | number | boolean,

--- a/liwords-ui/src/store/reducers/lobby_reducer.ts
+++ b/liwords-ui/src/store/reducers/lobby_reducer.ts
@@ -64,6 +64,7 @@ export type LobbyState = {
       [k: string]: ProfileUpdate.Rating;
     };
   };
+  lobbyFilterByLexicon: string | null;
 };
 
 export const SeekRequestToSoughtGame = (
@@ -285,6 +286,14 @@ export function LobbyReducer(state: LobbyState, action: Action): LobbyState {
           ...profile,
           ratings,
         },
+      };
+    }
+
+    case ActionType.setLobbyFilterByLexicon: {
+      const newLexiconFilter = action.payload as string | null;
+      return {
+        ...state,
+        lobbyFilterByLexicon: newLexiconFilter,
       };
     }
   }

--- a/liwords-ui/src/store/store.tsx
+++ b/liwords-ui/src/store/store.tsx
@@ -232,6 +232,7 @@ const LobbyContext = createContext<LobbyStoreData>({
     activeGames: [],
     matchRequests: [],
     profile: { ratings: {} },
+    lobbyFilterByLexicon: localStorage.getItem('lobbyFilterByLexicon'),
   },
   dispatchLobbyContext: defaultFunction,
 });
@@ -786,6 +787,7 @@ const RealStore = ({ children, ...props }: Props) => {
     activeGames: [],
     matchRequests: [],
     profile: { ratings: {} },
+    lobbyFilterByLexicon: localStorage.getItem('lobbyFilterByLexicon'),
   });
   const dispatchLobbyContext = useCallback(
     (action) => setLobbyContext((state) => LobbyReducer(state, action)),


### PR DESCRIPTION
@domino14 I'm able to reset `lobbyFilterByLexicon` in the state and localStorage when I create a new seek, but active games and sought games components are not updating, they still show the filter. If I change between the taps Play and Watch it updates and goes away. For some reason the change in the store is not triggering a rerender