### PR TITLE
band-aid duplicate first event pool bug for bot games

### DIFF
--- a/liwords-ui/src/store/reducers/game_reducer.ts
+++ b/liwords-ui/src/store/reducers/game_reducer.ts
@@ -12,6 +12,7 @@ import {
   Blank,
   PlayedTiles,
   PlayerOfTiles,
+  EmptySpace,
 } from '../../utils/cwgame/common';
 import { PlayerOrder } from '../constants';
 import { ClockController, Millis } from '../timer_controller';
@@ -222,7 +223,7 @@ const placeOnBoard = (
         ? evt.getColumn() + i
         : evt.getColumn();
     const tile = { row, col, rune };
-    if (rune !== ThroughTileMarker) {
+    if (rune !== ThroughTileMarker && board.letterAt(row, col) === EmptySpace) {
       board.addTile(tile);
       if (isBlank(tile.rune)) {
         newPool[Blank] -= 1;
@@ -253,7 +254,7 @@ const unplaceOnBoard = (
         ? evt.getColumn() + i
         : evt.getColumn();
     const tile = { row, col, rune };
-    if (rune !== ThroughTileMarker) {
+    if (rune !== ThroughTileMarker && board.letterAt(row, col) !== EmptySpace) {
       // Remove the tile from the board and place it back in the pool.
       board.removeTile(tile);
       if (isBlank(tile.rune)) {


### PR DESCRIPTION
In a game where the bot went first:
- GameHistoryRefresher can contain the first play in its list of game events
- Separately, front-end also receives a `SERVER_GAMEPLAY_EVENT` with the first play
- front-end code removes this first play twice from the pool
- this PR fixes that double deduction

It does not fix the fact that the backend sends the game event twice. This seems to have been brought on by #1023 -- need to investigate how exactly and fix the backend. Perhaps the db code is too fast now.