### PR TITLE
Games migration draft/skeleton/design/needs feedback

### DIFF
--- a/db/migrations/202207192223_games_migration.down.sql
+++ b/db/migrations/202207192223_games_migration.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+DROP TABLE IF EXISTS omgwords CASCADE;
+DROP TABLE IF EXISTS omgwords_turns CASCADE;
+DROP TABLE IF EXISTS omgwords_requests CASCADE;
+DROP TABLE IF EXISTS omgwords_tournament_data CASCADE;
+DROP TABLE IF EXISTS omgwords_meta_events CASCADE;
+DROP TABLE IF EXISTS omgwords_stats CASCADE;
+
+COMMIT;

--- a/db/migrations/202207192223_games_migration.up.sql
+++ b/db/migrations/202207192223_games_migration.up.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS omgwords (
+
+);
+
+CREATE TABLE IF NOT EXISTS omgwords_turns (
+
+);
+
+CREATE TABLE IF NOT EXISTS omgwords_requests (
+
+);
+
+CREATE TABLE IF NOT EXISTS omgwords_tournament_data (
+
+);
+
+CREATE TABLE IF NOT EXISTS omgwords_meta_events (
+
+);
+
+CREATE TABLE IF NOT EXISTS omgwords_stats (
+
+);
+
+COMMIT;

--- a/pkg/gameplay/end.go
+++ b/pkg/gameplay/end.go
@@ -205,6 +205,15 @@ func performEndgameDuties(ctx context.Context, g *entity.Game, gameStore GameSto
 
 	// send each player their new profile with updated ratings.
 	sendProfileUpdate(ctx, g, users)
+
+	// Asynchronously write the game stats to the db the new way:
+	// go func() {
+	// 	err := omgwords.HandleGameEnded(ctx, g)
+	// 	if err != nil {
+	// 		log.Info().Err(err)
+	// 	}
+	// }()
+
 	return nil
 }
 

--- a/pkg/stores/game/db.go
+++ b/pkg/stores/game/db.go
@@ -508,6 +508,14 @@ func (s *DBStore) Set(ctx context.Context, g *entity.Game) error {
 	result := ctxDB.Model(&game{}).Clauses(clause.Locking{Strength: "UPDATE"}).
 		Where("uuid = ?", g.GameID()).Updates(dbg)
 
+	// Asynchronously write the game to the db the new way:
+	// go func() {
+	// 	err := omgwords.Set(ctx, g)
+	// 	if err != nil {
+	// 		log.Info().Err(err)
+	// 	}
+	// }()
+
 	return result.Error
 }
 

--- a/pkg/stores/omgwords/db.go
+++ b/pkg/stores/omgwords/db.go
@@ -1,0 +1,39 @@
+package omgwords
+
+import (
+	"context"
+
+	"github.com/domino14/liwords/pkg/entity"
+	"github.com/jackc/pgx/v4/pgxpool"
+)
+
+type DBStore struct {
+	dbPool *pgxpool.Pool
+}
+
+func NewDBStore(p *pgxpool.Pool) (*DBStore, error) {
+	return &DBStore{dbPool: p}, nil
+}
+
+func (s *DBStore) Disconnect() {
+	s.dbPool.Close()
+}
+
+func (s *DBStore) Create(ctx context.Context, g *entity.Game) error {
+	// Create row in omgwords table
+	// Create row in omgwords_requests table
+	// Create row in omgwords_tournament_data table
+	return nil
+}
+
+func (s *DBStore) Set(ctx context.Context, g *entity.Game) error {
+	// Conditionally create row in omgwords_turns
+	// Conditionally create row in omgwords_meta_events
+	// Conditionally modify omgwords table
+	return nil
+}
+
+func (s *DBStore) HandleGameEnded(ctx context.Context, g *entity.Game) error {
+	// Create row in omgwords_stats
+	return nil
+}


### PR DESCRIPTION
Skeleton code for the games migration. For now, this draft PR can be treated more as a design that implementation. This might be deleted or rewritten as designs change. I find it easier to convey the ideas in code. The rough idea for a games migration that I'm thinking of is:

1. Implement omgwords db paradigm
2. Write to the omgwords db in parallel with the current db. Nothing depends on the omgwords tables yet.
3. Migrate old games to the omgwords paradigm. After this step, all games should be under the new omgwords paradigm
4. Read games from the omgwords tables.
5. Delete or move old games if needed.

Not sure if this is the right direction. Feedback is needed.