### PR TITLE
use sync.Pool only with pointer type

### DIFF
--- a/pkg/words/definition.go
+++ b/pkg/words/definition.go
@@ -38,7 +38,8 @@ func loadDefinitionSource(filename string) (*defSource, error) {
 
 var bufPool = sync.Pool{
 	New: func() interface{} {
-		return []byte(nil)
+		var x []byte
+		return &x
 	},
 }
 
@@ -47,12 +48,13 @@ func (ds *defSource) bulkDefine(sortedWords []string) (map[string]string, error)
 	fileSize := ds.fileSize
 	blkSize := ds.blkSize
 
-	pooledBuf := bufPool.Get().([]byte)
-	if cap(pooledBuf) < int(blkSize) {
-		pooledBuf = make([]byte, int(blkSize))
+	pooledBuf := bufPool.Get().(*[]byte)
+	if cap(*pooledBuf) < int(blkSize) {
+		newPooledBuf := make([]byte, int(blkSize))
+		pooledBuf = &newPooledBuf
 	}
 	defer bufPool.Put(pooledBuf)
-	buf := pooledBuf[:blkSize]
+	buf := (*pooledBuf)[:blkSize]
 	bufMin := int64(0)
 	bufMax := int64(0)
 	numBlks := (fileSize + blkSize - 1) / blkSize

--- a/pkg/words/word_service.go
+++ b/pkg/words/word_service.go
@@ -57,7 +57,7 @@ func NewWordService(cfg *macondoconfig.Config) *WordService {
 
 var daPool = sync.Pool{
 	New: func() interface{} {
-		return gaddag.DawgAnagrammer{}
+		return &gaddag.DawgAnagrammer{}
 	},
 }
 
@@ -76,7 +76,7 @@ func (ws *WordService) DefineWords(ctx context.Context, req *pb.DefineWordsReque
 	var anagrams map[string][]string
 	if req.Anagrams {
 		anagrams = make(map[string][]string)
-		da := daPool.Get().(gaddag.DawgAnagrammer)
+		da := daPool.Get().(*gaddag.DawgAnagrammer)
 		defer daPool.Put(da)
 		for _, query := range req.Words {
 			if _, found := anagrams[query]; found {


### PR DESCRIPTION
fixes `argument should be pointer-like to avoid allocations (SA6002)` reported by [staticcheck](https://staticcheck.io/docs/checks/#SA6002)

analogous to https://github.com/domino14/macondo/pull/180

(this PR does not include changing go.mod to link to that specific macondo commit)