### PR TITLE
make temporarily bigger NATS channels. attempt to fix #1133

### DIFF
--- a/liwords-ui/src/setupTests.ts
+++ b/liwords-ui/src/setupTests.ts
@@ -1,3 +1,7 @@
+/**
+ * @jest-environment jsdom
+ */
+
 // jest-dom adds custom jest matchers for asserting on DOM nodes.
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
@@ -21,14 +25,14 @@ const mocks = {
   },
 };
 
-global.localStorage = mocks.localStorage;
-
-global.Audio = jest.fn().mockImplementation(() => ({
+const audio = jest.fn().mockImplementation(() => ({
   pause: mocks.Audio.pause,
   play: mocks.Audio.play,
   load: mocks.Audio.load,
   addEventListener: mocks.Audio.addEventListener,
 }));
 
-global.TextEncoder = TextEncoder;
-global.TextDecoder = TextDecoder;
+Object.defineProperty(window, 'localStorage', { value: mocks.localStorage });
+Object.defineProperty(window, 'Audio', { value: audio });
+Object.defineProperty(window, 'TextEncoder', { value: TextEncoder });
+Object.defineProperty(window, 'TextDecoder', { value: TextDecoder });

--- a/liwords-ui/src/store/reducers/tournament_reducer.test.ts
+++ b/liwords-ui/src/store/reducers/tournament_reducer.test.ts
@@ -1,5 +1,5 @@
 /**
- * @jest-environment node
+ * @jest-environment jsdom
  */
 // ^^ see https://github.com/jsdom/jsdom/issues/2524#issuecomment-902027138
 import { ActionType } from '../../actions/actions';

--- a/pkg/bus/bus.go
+++ b/pkg/bus/bus.go
@@ -142,7 +142,7 @@ func NewBus(cfg *config.Config, stores Stores, redisPool *redis.Pool) (*Bus, err
 	}
 
 	for _, topic := range topics {
-		ch := make(chan *nats.Msg, 64)
+		ch := make(chan *nats.Msg, 512)
 		var err error
 		var sub *nats.Subscription
 		if strings.Contains(topic, ".request.") {


### PR DESCRIPTION
This is meant to be a band-aid. 

What is happening (I believe):

- liwords is listening on `user.>`
- this channel is extremely bursty. It contains not only a large number of game events, but all presence/activegame events when people enter/join games, for all of their followers. People with large numbers of followers fill up the buffer quickly, and NATS starts dropping messages
- perhaps NATS gets into a state where it has dropped too many messages and drops the connection briefly? Therefore no NATS events are getting through.

The correct way to fix this is to redo presence events; it is very very unoptimized right now. Will have a basic tech doc for it.