### PR TITLE
a hideous function to fix norwegian/german/etc sort issue

### DIFF
--- a/pkg/cwgame/dawg/anagrammer.go
+++ b/pkg/cwgame/dawg/anagrammer.go
@@ -40,10 +40,7 @@ func findMachineWord(d *SimpleDawg, nodeIdx uint32, word runemapping.MachineWord
 	var numArcs, i byte
 	var letter runemapping.MachineLetter
 	var nextNodeIdx uint32
-
 	if curIdx == uint8(len(word)-1) {
-		// log.Println("checking letter set last Letter", string(letter),
-		// 	"nodeIdx", nodeIdx, "word", string(word))
 		ml := word[curIdx]
 		return d.InLetterSet(ml, nodeIdx), nodeIdx
 	}
@@ -54,8 +51,6 @@ func findMachineWord(d *SimpleDawg, nodeIdx uint32, word runemapping.MachineWord
 		nextNodeIdx, letter = d.ArcToIdxLetter(nodeIdx + uint32(i))
 		curml := word[curIdx]
 		if letter == curml {
-			// log.Println("Letter", string(letter), "this node idx", nodeIdx,
-			// 	"next node idx", nextNodeIdx, "word", string(word))
 			found = true
 			break
 		}

--- a/pkg/cwgame/dawg/anagrammer_test.go
+++ b/pkg/cwgame/dawg/anagrammer_test.go
@@ -113,3 +113,45 @@ func TestFindMachineWord(t *testing.T) {
 		})
 	}
 }
+
+var findNorwegianWordTests = []testpair{
+	{"ABACAER", true},
+	{"ÅMA", true},
+	{"AMÅ", false},
+	{"ÜBERKUL", true}, // takes an E and a T!
+}
+
+func TestFindMachineWordNorwegian(t *testing.T) {
+	is := is.New(t)
+	d, _ := LoadDawg(filepath.Join(DefaultConfig.DataPath, "lexica", "dawg", "NSF22.dawg"))
+	for _, pair := range findNorwegianWordTests {
+		t.Run(pair.prefix, func(t *testing.T) {
+			mw, err := runemapping.ToMachineLetters(pair.prefix, d.GetRuneMapping())
+			is.NoErr(err)
+			found := d.HasWord(mw)
+			is.Equal(found, pair.found)
+		})
+	}
+}
+
+var hasAnagramNorwegianTests = []testpair{
+	{"BRACEAA", true},
+	{"MÅA", true},
+	{"AMÅA", false},
+	{"BELRÜUK", true},
+	{"BELRSÜUK", false},
+	{"BELRTÜUK", true},
+}
+
+func TestHasAnagramNorwegian(t *testing.T) {
+	is := is.New(t)
+	d, _ := LoadDawg(filepath.Join(DefaultConfig.DataPath, "lexica", "dawg", "NSF22.dawg"))
+	for _, pair := range hasAnagramNorwegianTests {
+		t.Run(pair.prefix, func(t *testing.T) {
+			mw, err := runemapping.ToMachineLetters(pair.prefix, d.GetRuneMapping())
+			is.NoErr(err)
+			found := d.HasAnagram(mw)
+			is.Equal(found, pair.found)
+		})
+	}
+}

--- a/pkg/cwgame/runemapping/alphabet.go
+++ b/pkg/cwgame/runemapping/alphabet.go
@@ -200,6 +200,7 @@ func (rm *RuneMapping) genLetterSlice(sortMap map[rune]int) {
 	for rn := range rm.vals {
 		rm.letterSlice = append(rm.letterSlice, rn)
 	}
+
 	if sortMap != nil {
 		sort.Slice(rm.letterSlice, func(i, j int) bool {
 			return sortMap[rm.letterSlice[i]] < sortMap[rm.letterSlice[j]]


### PR DESCRIPTION
fix #1142 

This is a hack. This needs to get fixed properly.
- Use a dawg without a hardcoded alphabet order; instead parse these from a separate file
- Or use kwg structure