### PR TITLE
fix go install sqlc

### DIFF
--- a/Dockerfile-goutils
+++ b/Dockerfile-goutils
@@ -28,7 +28,7 @@ RUN mv /tmp/buf /opt
 
 # Install sqlc
 
-RUN go install github.com/kyleconroy/sqlc/cmd/sqlc@latest
+RUN go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 
 FROM node:latest
 


### PR DESCRIPTION
it moved
https://github.com/sqlc-dev/sqlc/pull/2548

```
------
 > [goutils base 12/12] RUN go install github.com/kyleconroy/sqlc/cmd/sqlc@latest:
1.236 go: downloading github.com/kyleconroy/sqlc v1.20.0
2.024 go: github.com/kyleconroy/sqlc/cmd/sqlc@latest: github.com/kyleconroy/sqlc@v1.20.0: parsing go.mod:
2.024 	module declares its path as: github.com/sqlc-dev/sqlc
2.024 	        but was required as: github.com/kyleconroy/sqlc
------
failed to solve: process "/bin/sh -c go install github.com/kyleconroy/sqlc/cmd/sqlc@latest" did not complete successfully: exit code: 1
```