### PR TITLE
Header for tied game in profile is hard to read

### DIFF
--- a/liwords-ui/src/profile/profile.scss
+++ b/liwords-ui/src/profile/profile.scss
@@ -216,7 +216,7 @@
     }
     .ant-card-head {
       @include colorModed() {
-        background-color: m($timer-low-light);
+        background-color: m($timer-low-dark);
       }
     }
     &.win {


### PR DESCRIPTION
I finally had a game end in a tie. The text is difficult to read because the background is so light.
I changed it to a darker colour available within the colour scheme.

![Capture](https://github.com/domino14/liwords/assets/106636012/50d9d007-306f-49f5-8ef6-774d5ceec973)
