### PR TITLE
Clarify that resigning unrated games won't affect your rating

### DIFF
--- a/liwords-ui/src/gameroom/game_controls.tsx
+++ b/liwords-ui/src/gameroom/game_controls.tsx
@@ -452,7 +452,7 @@ const GameControls = React.memo((props: Props) => {
               // XXX: what if it's unrated?
               content: (
                 <p className="readable-text-color">
-                  Your rating may be affected.
+                  If this is a rated game, your rating may be affected.
                 </p>
               ),
               onOk() {


### PR DESCRIPTION
The message that currently appears when you resign a game could mislead players into thinking they will lose rating for resigning unrated games.
