### PR TITLE
Header for tied game hard to read in dark mode

### DIFF
--- a/liwords-ui/src/color_modes.scss
+++ b/liwords-ui/src/color_modes.scss
@@ -77,6 +77,10 @@ $timer-low-dark: 'color-timer-low-dark';
 $timer-out-light: 'color-timer-out-light';
 $timer-out-dark: 'color-timer-out-dark';
 
+$profile-game-win: 'color-profile-game-win';
+$profile-game-tie: 'color-profile-game-tie';
+$profile-game-loss: 'color-profile-game-loss';
+
 $shadow: 'shadow';
 $shadow-lower: 'shadow-lower';
 $board-shadow: 'board-shadow';
@@ -148,6 +152,10 @@ $modes: (
           color-timer-low-dark: #f4b000,
           color-timer-out-light: #ffeaea,
           color-timer-out-dark: #a92e2e,
+
+          color-profile-game-win: #e5ffdf,
+          color-profile-game-tie: #fbe5ae,
+          color-profile-game-loss: #ffeaea
         ),
         dark: (
           shadow: 0px 0px 12px rgba(0, 0, 0, 0.2),
@@ -215,6 +223,10 @@ $modes: (
           color-timer-low-dark: #f4b000,
           color-timer-out-light: #561f22,
           color-timer-out-dark: #ce5f66,
+
+          color-profile-game-win: #24542d,
+          color-profile-game-tie: #f4b000,
+          color-profile-game-loss: #561f22
         ),
 );
 

--- a/liwords-ui/src/profile/profile.scss
+++ b/liwords-ui/src/profile/profile.scss
@@ -216,20 +216,20 @@
     }
     .ant-card-head {
       @include colorModed() {
-        background-color: m($timer-low-light);
+        background-color: m($profile-game-tie);
       }
     }
     &.win {
       .ant-card-head {
         @include colorModed() {
-          background-color: m($timer-light);
+          background-color: m($profile-game-win);
         }
       }
     }
     &.loss {
       .ant-card-head {
         @include colorModed() {
-          background-color: m($timer-out-light);
+          background-color: m($profile-game-loss;
         }
       }
     }

--- a/liwords-ui/src/profile/profile.scss
+++ b/liwords-ui/src/profile/profile.scss
@@ -229,7 +229,7 @@
     &.loss {
       .ant-card-head {
         @include colorModed() {
-          background-color: m($profile-game-loss;
+          background-color: m($profile-game-loss);
         }
       }
     }


### PR DESCRIPTION
I finally had a game end in a tie. The text is difficult to read because the background is so light.
I changed it to a darker colour available within the colour scheme.

(This is a more "proper" fix that defines separate colours for the profile game headers instead of re-using the timer colours. This means it can be kept the same in light mode, where it look OK, and only changed in dark mode.)

![Capture](https://github.com/domino14/liwords/assets/106636012/7af7d740-3628-4875-a1f8-f92bfd5e87de)

